### PR TITLE
Add some more commonly expected packages.

### DIFF
--- a/debootstrap/jessie
+++ b/debootstrap/jessie
@@ -36,10 +36,12 @@ work_out_debs () {
     # mawk as it is used by dpkg
     # passwd for managing user accounts if run as non-root.
     # sed as a very commonly used tool
+    # sysv-rc for update-rc.d, required when installing initscripts in postinsts
     # tar as uncompressing tarballs is super common when installing things.
     # tzdata for handling timezones
-    # mount is required for mounting /proc during installation, may remove after
-	required="adduser base-files base-passwd bash coreutils dash debian-archive-keyring diffutils dpkg findutils grep gzip hostname libc-bin login lsb-base mawk passwd sed tar tzdata mount"
+    # util-linux for getopt
+    # mount is required for mounting /proc during debootstrap
+	required="adduser base-files base-passwd bash coreutils dash debian-archive-keyring diffutils dpkg findutils grep gzip hostname libc-bin login lsb-base mawk passwd sed sysv-rc tar tzdata util-linux mount"
 
 	base="apt"
 

--- a/mkimage
+++ b/mkimage
@@ -27,43 +27,6 @@ DIRS_TO_TRIM="/usr/share/man
 /usr/share/info
 "
 
-PACKAGES_TO_EXCLUDE="acl
-bsdutils
-debconf-i18n
-dmsetup
-e2fslibs
-e2fsprogs
-gcc-4.8-base
-init
-initscripts
-insserv
-libcap2
-libcap2-bin
-libcryptsetup4
-libdevmapper1.02.1
-libkmod2
-liblocale-gettext-perl
-libmount1
-libncursesw5
-libprocps3
-libsystemd0
-libtext-charwidth-perl
-libtext-iconv-perl
-libtext-wrapi18n-perl
-libudev1
-mount
-ncurses-bin
-ncurses-base
-procps
-startpar
-systemd
-systemd-sysv
-sysv-rc
-sysvinit-utils
-udev
-util-linux
-"
-
 rootfsDir=$(mktemp -d)
 echo "Building base in $rootfsDir"
 DEBOOTSTRAP_DIR=$DEBOOTSTRAP_DIR debootstrap --variant container --foreign ${DIST} "$rootfsDir"
@@ -209,7 +172,6 @@ chmod 0755 "$rootfsDir/usr/sbin/install_packages"
 
 
 echo "Trimming down"
-chroot "$rootfsDir" dpkg --force-all -P $PACKAGES_TO_EXCLUDE
 for DIR in $DIRS_TO_TRIM; do
   rm -r "$rootfsDir/$DIR"/*
 done

--- a/test
+++ b/test
@@ -8,4 +8,7 @@ docker run --rm "$IMAGE_ID" dpkg -l apt
 docker run --rm -e DEBIAN_FRONTEND=noninteractive "$IMAGE_ID" bash -c 'apt-get update && apt-get -y install less && less --help >/dev/null'
 docker run --rm -e DEBIAN_FRONTEND=noninteractive "$IMAGE_ID" bash -c 'install_packages less  && less --help >/dev/null && [ ! -e /var/cache/apt/archives ] && [ ! -e /var/lib/apt/lists ]'
 docker run --rm -e DEBIAN_FRONTEND=noninteractive "$IMAGE_ID" bash -c '[ ! -e /debootstrap ]'
+# Ask apt to install all packages that are already installed, has the effect of checking the
+# dependencies are correctly available
+docker run --rm -e DEBIAN_FRONTEND=noninteractive "$IMAGE_ID" bash -c 'apt-get update && (dpkg-query -W -f \${Package} | while read pkg; do apt-get install $pkg; done)'
 


### PR DESCRIPTION
sysv-rc and util-linux are used in the postinst scripts
of some packages, and so those packages won't install
if they aren't available.

sysv-rc contains update-rc.d, so any package that installs
a service would fail to install. Those packages are common
to install in to containers.

util-linux contains the getopt command which some scripts
expect to find.