### PR TITLE
Retry apt if it fails in `install_packages`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ small images, and having many quality packages available
 for easy integration.
 
 These images also include an `install_packages` command
-that you can use instead of apt. This does two things:
+that you can use instead of apt. This takes care of some things
+for you:
 
   1. Install the named packages, skipping prompts etc.
   2. Clean up the apt metadata afterwards to keep the image small.
+  3. Retrying if apt fails. Sometimes a package will fail to download
+     due to a network issue, and this may fix that, which is
+     particularly useful in an automated build pipeline.
 
 e.g.
 

--- a/mkimage
+++ b/mkimage
@@ -164,8 +164,25 @@ cat > "$rootfsDir/usr/sbin/install_packages" <<-'EOF'
 set -e
 set -u
 export DEBIAN_FRONTEND=noninteractive
-apt-get update -qq
-apt-get install -y --no-install-recommends "$@"
+n=0
+max=2
+until [ $n -gt max  ]; do
+    set +e
+    (
+      apt-get update -qq &&
+      apt-get install -y --no-install-recommends "$@"
+    )
+    CODE=$?
+    set -e
+    if [ $CODE -eq 0 ]; then
+        break
+    fi
+    if [ $n -eq $max ]; then
+        exit $CODE
+    fi
+    echo "apt failed, retrying"
+    n=$[$n+1]
+done
 rm -r /var/lib/apt/lists /var/cache/apt/archives
 EOF
 chmod 0755 "$rootfsDir/usr/sbin/install_packages"


### PR DESCRIPTION
Sometimes apt will fail due a transient network issue. Often that
will be fixed by retrying.

This is particularly useful as part of an automated build pipeline.