### PR TITLE
Only push images if they have changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: bash
 sudo: required
 script: sudo bash buildall
+dist: trusty
 services:
   - docker
 before_install:

--- a/buildall
+++ b/buildall
@@ -2,6 +2,7 @@
 
 set -e
 set -u
+set -o pipefail
 
 DISTS="jessie
 unstable
@@ -14,17 +15,34 @@ GCR_BASENAME=gcr.io/bitnami-containers/minideb
 
 mkdir -p build
 
+import() {
+    SOURCE=$1
+    docker import --change "CMD /bin/bash" -m "From Bitnami with love." $SOURCE
+}
+
 for DIST in $DISTS; do
    [ -f debootstrap/$DIST ] || (echo "buildall: Unknown distribution: $DIST" && exit 1)
    echo "============================================"
    echo "Building $BASENAME:$DIST"
    echo "============================================"
    ./mkimage build/$DIST.tar $DIST
-   IMPORTED=$(docker import --change "CMD /bin/bash" build/$DIST.tar)
+   IMPORTED=$(import build/$DIST.tar)
    echo "============================================"
    echo "Running tests for $BASENAME:$DIST"
    echo "============================================"
    ./test $IMPORTED
+   echo "============================================"
+   echo "Rebuilding $BASENAME:$DIST to test reproducability"
+   echo "============================================"
+   ./mkimage build/${DIST}-repro.tar $DIST
+   REPRO=$(import build/${DIST}-repro.tar)
+   if ! ./dockerdiff $IMPORTED $REPRO; then
+       echo "$BASENAME:$DIST differs after a rebuild. Examine $IMPORTED and $REPRO"
+       echo "to find the differences and fix the build to be reproducible again."
+       exit 1
+   fi
+   rm build/${DIST}-repro.tar
+   docker rmi $REPRO
    docker tag $IMPORTED $BASENAME:$DIST
    docker tag $IMPORTED $GCR_BASENAME:$DIST
 done

--- a/dockerdiff
+++ b/dockerdiff
@@ -16,7 +16,7 @@ dpkgl() {
 }
 
 lslr() {
-    docker run --rm $1 bash -c 'find / -path /proc -prune -o -print0 | xargs -0 ls -ld'
+    docker run --rm $1 bash -c 'find / -xdev -print0 | sort -z | xargs -0 ls -ld'
 }
 
 if ! diff -u <(inspect $IMAGE1) <(inspect $IMAGE2); then

--- a/dockerdiff
+++ b/dockerdiff
@@ -2,13 +2,20 @@
 
 set -e
 set -u
+set -o pipefail
 
 IMAGE1=$1
 IMAGE2=$2
 
-TMPDIR=$(mktemp -d -t dockerdiff.XXXXXXXXXX)
+inspect() {
+    docker inspect $1 | jq ".[0]|del(.Id,.RepoTags,.RepoDigests,.Created)"
+}
 
-docker run --rm $IMAGE1 dpkg -l > $TMPDIR/a
-docker run --rm $IMAGE2 dpkg -l > $TMPDIR/b
+lslr() {
+    docker run --rm $1 ls -lR /
+}
 
-exec diff -u $TMPDIR/a $TMPDIR/b
+if ! diff -u <(inspect $IMAGE1) <(inspect $IMAGE2); then
+    diff -u <(lslr $IMAGE1) <(lslr $IMAGE2)
+    exit 1
+fi

--- a/dockerdiff
+++ b/dockerdiff
@@ -16,7 +16,7 @@ dpkgl() {
 }
 
 lslr() {
-    docker run --rm $1 ls -lR /
+    docker run --rm $1 bash -c 'find / -path /proc -prune -o -print0 | xargs -0 ls -ld'
 }
 
 if ! diff -u <(inspect $IMAGE1) <(inspect $IMAGE2); then

--- a/dockerdiff
+++ b/dockerdiff
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+set -u
+
+IMAGE1=$1
+IMAGE2=$2
+
+TMPDIR=$(mktemp -d -t dockerdiff.XXXXXXXXXX)
+
+docker run --rm $IMAGE1 dpkg -l > $TMPDIR/a
+docker run --rm $IMAGE2 dpkg -l > $TMPDIR/b
+
+exec diff -u $TMPDIR/a $TMPDIR/b

--- a/dockerdiff
+++ b/dockerdiff
@@ -11,11 +11,16 @@ inspect() {
     docker inspect $1 | jq ".[0]|del(.Id,.RepoTags,.RepoDigests,.Created)"
 }
 
+dpkgl() {
+    docker run --rm $1 dpkg -l
+}
+
 lslr() {
     docker run --rm $1 ls -lR /
 }
 
 if ! diff -u <(inspect $IMAGE1) <(inspect $IMAGE2); then
-    diff -u <(lslr $IMAGE1) <(lslr $IMAGE2)
+    diff -u <(dpkgl $IMAGE1) <(dpkgl $IMAGE2) || true
+    diff -u <(lslr $IMAGE1) <(lslr $IMAGE2) || true
     exit 1
 fi

--- a/mkimage
+++ b/mkimage
@@ -192,7 +192,7 @@ chmod 0755 "$rootfsDir/usr/sbin/install_packages"
 # Capture the most recent date that a package in the image was changed.
 # We don't care about the particular date, or which package it comes from,
 # we just need a date that isn't very far in the past.
-BUILD_DATE="$(find $rootfsDir/usr/share/doc -name changelog.Debian.gz -print0 | xargs -0 -l dpkg-parsechangelog -SDate -l | xargs -l -i date --date="{}" +%s | sort -n | tail -n 1)"
+BUILD_DATE="$(find $rootfsDir/usr/share/doc -name changelog.Debian.gz -exec dpkg-parsechangelog -SDate -l'{}' \; | xargs -l -i date --date="{}" +%s | sort -n | tail -n 1)"
 echo "Trimming down"
 for DIR in $DIRS_TO_TRIM; do
   rm -r "$rootfsDir/$DIR"/*

--- a/mkimage
+++ b/mkimage
@@ -45,6 +45,11 @@ chroot "$rootfsDir" dpkg -l | tee "$TARGET.manifest"
 
 echo "Applying docker-specific tweaks"
 # These are copied from the docker contrib/mkimage/debootstrap script.
+# Modifications:
+#  - remove `strings` check for applying the --force-unsafe-io tweak.
+#     This was sometimes wrongly detected as not applying, and we aren't
+#     interested in building versions that this guard would apply to,
+#     so simply apply the tweak unconditionally.
 
 # get path to "chroot" in our current PATH
 chrootPath="$(type -P chroot)"
@@ -83,18 +88,15 @@ chmod +x "$rootfsDir/usr/sbin/policy-rc.d"
 # don't even have kernels installed
 rm -f "$rootfsDir/etc/apt/apt.conf.d/01autoremove-kernels"
 
-# Ubuntu 10.04 sucks... :)
-if strings "$rootfsDir/usr/bin/dpkg" | grep -q unsafe-io; then
-	# force dpkg not to call sync() after package extraction (speeding up installs)
-	echo >&2 "+ echo force-unsafe-io > '$rootfsDir/etc/dpkg/dpkg.cfg.d/docker-apt-speedup'"
-	cat > "$rootfsDir/etc/dpkg/dpkg.cfg.d/docker-apt-speedup" <<-'EOF'
-		# For most Docker users, package installs happen during "docker build", which
-		# doesn't survive power loss and gets restarted clean afterwards anyhow, so
-		# this minor tweak gives us a nice speedup (much nicer on spinning disks,
-		# obviously).
-		force-unsafe-io
-	EOF
-fi
+# force dpkg not to call sync() after package extraction (speeding up installs)
+echo >&2 "+ echo force-unsafe-io > '$rootfsDir/etc/dpkg/dpkg.cfg.d/docker-apt-speedup'"
+cat > "$rootfsDir/etc/dpkg/dpkg.cfg.d/docker-apt-speedup" <<-'EOF'
+# For most Docker users, package installs happen during "docker build", which
+# doesn't survive power loss and gets restarted clean afterwards anyhow, so
+# this minor tweak gives us a nice speedup (much nicer on spinning disks,
+# obviously).
+force-unsafe-io
+EOF
 
 if [ -d "$rootfsDir/etc/apt/apt.conf.d" ]; then
 	# _keep_ us lean by effectively running "apt-get clean" after every install

--- a/mkimage
+++ b/mkimage
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 set -u
+set -o pipefail
 
 ROOT=$(cd $(dirname $0) && pwd)
 
@@ -40,7 +41,7 @@ fi
 chroot "$rootfsDir" apt-get update
 chroot "$rootfsDir" apt-get upgrade -y -o Dpkg::Options::="--force-confdef"
 
-chroot "rootfsDir" dpkg -l | tee "$TARGET.manifest"
+chroot "$rootfsDir" dpkg -l | tee "$TARGET.manifest"
 
 echo "Applying docker-specific tweaks"
 # These are copied from the docker contrib/mkimage/debootstrap script.
@@ -188,12 +189,22 @@ EOF
 chmod 0755 "$rootfsDir/usr/sbin/install_packages"
 
 
+# Capture the most recent date that a package in the image was changed.
+# We don't care about the particular date, or which package it comes from,
+# we just need a date that isn't very far in the past.
+BUILD_DATE="$(find $rootfsDir/usr/share/doc -name changelog.Debian.gz -print0 | xargs -0 -l dpkg-parsechangelog -SDate -l | xargs -l -i date --date="{}" +%s | sort -n | tail -n 1)"
 echo "Trimming down"
 for DIR in $DIRS_TO_TRIM; do
   rm -r "$rootfsDir/$DIR"/*
 done
+rm "$rootfsDir/var/cache/ldconfig/aux-cache"
 find "$rootfsDir/usr/share/doc" -mindepth 1 -not -name copyright -not -type d -delete
 find "$rootfsDir/usr/share/doc" -mindepth 1 -type d -empty -delete
+# Set the mtime on all files to be no older than $BUILD_DATE.
+# This is required to have the same metadata on files so that the
+# same tarball is produced. We assume that it is not important
+# that any file have a newer mtime than this.
+find "$rootfsDir" -depth -newermt "@$BUILD_DATE" -print0 | xargs -0r touch --no-dereference --date="@$BUILD_DATE"
 echo "Total size"
 du -skh "$rootfsDir"
 echo "Package sizes"

--- a/pushall
+++ b/pushall
@@ -2,12 +2,9 @@
 
 set -e
 set -u
+set -o pipefail
 
-ONLY_IF_CHANGED=${ONLY_IF_CHANGED:-}
-
-if [ "${TRAVIS_EVENT_TYPE:-}" == "cron" ]; then
-    ONLY_IF_CHANGED=true
-fi
+PUSH_IF_CHANGED=${PUSH_IF_CHANGED:-}
 
 DISTS="jessie
 unstable
@@ -27,7 +24,7 @@ if [ -n "${GCR_KEY:-}" ]; then
 fi
 
 for DIST in $DISTS; do
-    if [ -n ${ONLY_IF_CHANGED} ]; then
+    if [ -z ${PUSH_IF_CHANGED} ]; then
         docker tag $BASENAME:$DIST $BASENAME:$DIST-save
         if docker pull $BASENAME:$DIST; then
             if ./dockerdiff $BASENAME:$DIST $BASENAME:$DIST-save; then

--- a/pushall
+++ b/pushall
@@ -3,30 +3,40 @@
 set -e
 set -u
 
+ONLY_IF_CHANGED=${ONLY_IF_CHANGED:-}
+
+if [ "${TRAVIS_EVENT_TYPE:-}" == "cron" ]; then
+    ONLY_IF_CHANGED=true
+fi
+
 DISTS="jessie
 unstable
 wheezy
+latest
 "
 
 BASENAME=bitnami/minideb
 GCR_BASENAME=gcr.io/bitnami-containers/minideb
 
-if [ -n "$DOCKER_PASSWORD" ]; then
+if [ -n "${DOCKER_PASSWORD:-}" ]; then
     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
 fi
 
-for DIST in $DISTS; do
-    docker push $BASENAME:$DIST
-done
-docker push $BASENAME:latest
-
-if [ -n "$GCR_KEY" ]; then
-    echo "$GCR_KEY" > keyfile.json
-    gcloud auth activate-service-account $GCR_EMAIL --key-file keyfile.json
+if [ -n "${GCR_KEY:-}" ]; then
+    gcloud auth activate-service-account $GCR_EMAIL --key-file <(echo "$GCR_KEY")
 fi
 
 for DIST in $DISTS; do
+    if [ -n ${ONLY_IF_CHANGED} ]; then
+        docker tag $BASENAME:$DIST $BASENAME:$DIST-save
+        if docker pull $BASENAME:$DIST; then
+            if ./dockerdiff $BASENAME:$DIST $BASENAME:$DIST-save; then
+                echo "Not pushing $DIST as it has not changed"
+                continue
+            fi
+        fi
+        docker tag $BASENAME:$DIST-save $BASENAME:$DIST
+    fi
+    docker push $BASENAME:$DIST
     gcloud docker push $GCR_BASENAME:$DIST
 done
-gcloud docker push $GCR_BASENAME:latest
-


### PR DESCRIPTION
We don't want to push new versions of the image if nothing has
changed. The builds aren't reproducible though, so we can't rely
on docker's layer logic to coalesce multiple builds of the same
packages.

Instead we define a `dockerdiff` that looks for differences in
the installed packages. This seems like a reasonable algorithm
for this.

We then change the push logic to first pull the currently
published image (after saving the local one to a different
name). If `dockerdiff` doesn't report any changes then
we skip pushing that image.

We control this behaviour via an env var, defaulting to off,
but we force it on if we are running in a travis cron job.
This means the daily builds will use this behaviour, but if you
push a change to this repo it will rebuild all the images. This
is because changing the scripts might change the images without
changing the package versions (e.g. changing install_packages),
so we want to trigger a push in those cases.