### PR TITLE
Only rebuild daily if a package changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y debian-archive-keyring debootstrap
+  - sudo apt-get install -y debian-archive-keyring debootstrap devscripts
 deploy:
   provider: script
   script: bash pushall

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Building
 
 You can build an image yourself if you wish:
 
-- Install debootstrap and debian-archive-keyring.
+- Install debootstrap, devscripts and debian-archive-keyring.
 - sudo ./buildall
 
 To build an individual image:

--- a/buildall
+++ b/buildall
@@ -14,6 +14,15 @@ GCR_BASENAME=gcr.io/bitnami-containers/minideb
 mkdir -p build
 
 for DIST in $DISTS; do
+   if [ "${TRAVIS_EVENT_TYPE-}" == "cron" ]; then
+       echo "============================================"
+       echo "Checking whether to build $DIST"
+       echo "============================================"
+       if ! ./shouldbuild $BASENAME:$DIST $DIST; then
+           echo "Not building $DIST as no new packages"
+           continue
+       fi
+   fi
    [ -f debootstrap/$DIST ] || (echo "buildall: Unknown distribution: $DIST" && exit 1)
    echo "============================================"
    echo "Building $BASENAME:$DIST"
@@ -26,6 +35,8 @@ for DIST in $DISTS; do
    ./test $IMPORTED
    docker tag $IMPORTED $BASENAME:$DIST
    docker tag $IMPORTED $GCR_BASENAME:$DIST
+   if [ "$DIST" == "$LATEST" ]; then
+       docker tag $BASENAME:$LATEST $BASENAME:latest
+       docker tag $GCR_BASENAME:$LATEST $GCR_BASENAME:latest
+   fi
 done
-docker tag $BASENAME:$LATEST $BASENAME:latest
-docker tag $GCR_BASENAME:$LATEST $GCR_BASENAME:latest

--- a/shouldbuild
+++ b/shouldbuild
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+IMAGE_TAG=${1:?Specify the tag of the image to check}
+DIST=${2:?Specify the distribution (jessie/etc.)}
+
+if ! docker pull $IMAGE_TAG; then
+    # Not present, so have to build it
+    exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -r $TMPDIR" EXIT
+
+_chdist() {
+    local cmd=$1
+    shift
+    chdist -d "$TMPDIR" "$cmd" $DIST "$@"
+}
+
+set_mirrors() {
+    local mirrors="deb http://httpredir.debian.org/debian $DIST main"
+    if [ "$DIST" != "unstable" ]; then
+        mirrors="$mirrors\ndeb http://security.debian.org/ $DIST/updates main"
+    fi
+    echo $mirrors > $TMPDIR/$DIST/etc/apt/sources.list
+}
+
+_chdist create > /dev/null
+set_mirrors
+_chdist apt-get update > /dev/null
+
+get_latest() {
+    _chdist apt-cache madison $1 |  awk '{print $3}q' | head -n 1
+}
+
+get_package_versions() {
+    local image_id=$1
+    docker run --rm $image_id dpkg-query -W -f '${Package} ${Version}\n'
+}
+
+has_not_changed() {
+    while read package version; do
+      local latest="$(get_latest $package)"
+      if [ "$latest" != "$version" ]; then
+          echo "$package($version -> $latest)"
+      fi
+  done
+}
+
+CHANGED="$(get_package_versions $IMAGE_TAG | has_not_changed)"
+if [ -z "$CHANGED" ]; then
+    exit 1
+fi
+echo "Changed for $IMAGE_TAG: $CHANGED"


### PR DESCRIPTION
When the build is triggered by CRON check whether any of
the packages changed before building each version.

This will prevent wasting build time and pushing new versions
if nothing has changed.

The builds triggered by new master revisions will still
push new versions, so any changes to the scripts will result
in a new image.