### PR TITLE
Install ncurses-base to get terminfo files.

### DIFF
--- a/debootstrap/jessie
+++ b/debootstrap/jessie
@@ -34,6 +34,8 @@ work_out_debs () {
     # login as su maybe used if run as non root (?)
     # lsb-base ?
     # mawk as it is used by dpkg
+    # ncurses-base for terminfo files as docker sets TERM=xterm
+    #   see https://github.com/bitnami/minideb/issues/17
     # passwd for managing user accounts if run as non-root.
     # sed as a very commonly used tool
     # sysv-rc for update-rc.d, required when installing initscripts in postinsts
@@ -41,7 +43,7 @@ work_out_debs () {
     # tzdata for handling timezones
     # util-linux for getopt
     # mount is required for mounting /proc during debootstrap
-	required="adduser base-files base-passwd bash coreutils dash debian-archive-keyring diffutils dpkg findutils grep gzip hostname libc-bin login lsb-base mawk passwd sed sysv-rc tar tzdata util-linux mount"
+	required="adduser base-files base-passwd bash coreutils dash debian-archive-keyring diffutils dpkg findutils grep gzip hostname libc-bin login lsb-base mawk ncurses-base passwd sed sysv-rc tar tzdata util-linux mount"
 
 	base="apt"
 

--- a/test
+++ b/test
@@ -12,7 +12,13 @@ function desc() {
 }
 
 function test() {
-    docker run --rm -e DEBIAN_FRONTEND=noninteractive "$IMAGE_ID" "$@"
+    test_extra_args '' "$@"
+}
+
+function test_extra_args() {
+    local extra_args=$1
+    shift
+    docker run --rm $extra_args -e DEBIAN_FRONTEND=noninteractive "$IMAGE_ID" "$@"
     echo ""
     echo TEST: OK
     echo ""
@@ -40,3 +46,7 @@ desc "Check that install_packages doesn't loop forever on failures"
 # We check that we didn't install the package afterwards, just in case a package gets added with that name.
 # We wrap the whole thing in a timeout so that it doesn't loop forever. It's not ideal to have a timeout as there may be spurious failures if the network is slow.
 test bash -c 'timeout 60 bash -c "(install_packages thispackagebetternotexist || true) && ! dpkg -l thispackagebetternotexist"'
+
+# See https://github.com/bitnami/minideb/issues/17
+desc "Checking that the terminfo is valid when running with -t (#17)"
+echo "" | test_extra_args '-t' bash -c 'install_packages procps && top -d1 -n1 -b'


### PR DESCRIPTION
It's an essential package designed for exactly this.
It's pretty small, so not a huge cost to putting it back in.

The problem is pervasive enough, and it's unlikely that
users will know how to fix it, that it's worth us solving
it in the base image.

Fixes #17 