### PR TITLE
add Bazel build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,9 @@
+sh_binary(
+    name = "build-all",
+    srcs = ["buildall"],
+)
+
+sh_binary(
+    name = "load-deps",
+    srcs = ["pre-build.sh"],
+)


### PR DESCRIPTION
This is very simple Bazel BUILD file for only building all version of minideb. Need a bit more work to figure out how to specify argument to `src` property in order to build individuals such as jessie, wheezy, etc (using `mkimage` provided script)

cc/ @sebgoa 