### PR TITLE
Fix arguments to `gcloud docker`

### DIFF
--- a/pushall
+++ b/pushall
@@ -29,5 +29,5 @@ fi
 for DIST in $DISTS; do
     docker push $BASENAME:$DIST
     docker push $QUAY_BASENAME:$DIST
-    gcloud docker push $GCR_BASENAME:$DIST
+    gcloud docker -- push $GCR_BASENAME:$DIST
 done


### PR DESCRIPTION
gcloud became more strict about separating gcloud arguments
from docker arguments, and is now throwing an error failing
the build https://travis-ci.org/bitnami/minideb/jobs/246281633#L5140

Use `--` to separate the arguments.