### PR TITLE
Fix for Travis build failures due to running apt cron service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ dist: xenial
 services:
   - docker
 before_install:
+  # Fix for Ubuntu Xenial apt-daily.service triggering
+  # https://unix.stackexchange.com/questions/315502/how-to-disable-apt-daily-service-on-ubuntu-cloud-vm-image
+  - |
+    sudo systemctl stop apt-daily.service &&
+    sudo systemctl kill --kill-who=all apt-daily.service &&
+    while ! (systemctl list-units --all apt-daily.service | fgrep -q dead) ; do
+      sleep 1
+    done
   - sudo apt-get -qq update
   - sudo apt-get install -y debian-archive-keyring debootstrap
 deploy:


### PR DESCRIPTION
>The Ubuntu 16.04 server VM image apparently starts the "apt-daily.service" every 12 hours or so; this service performs various APT-related tasks like refreshing the list of available packages, performing unattended upgrades if needed, etc.

>When starting from a VM "snapshot", the service is triggered immediately, as (I presume) systemd realizes quickly that the timer should have gone off long ago.

See issue happening at https://api.travis-ci.org/v3/job/352495521/log.txt

Thread at:
https://github.com/travis-ci/travis-cookbooks/issues/952

Possible workaround applied at:
https://unix.stackexchange.com/questions/315502/how-to-disable-apt-daily-service-on-ubuntu-cloud-vm-image
