### PR TITLE
update minideb-extras-base separatelly

### DIFF
--- a/pushall
+++ b/pushall
@@ -38,6 +38,8 @@ for DIST in $DISTS; do
     # Use '.RepoDigests 0' for getting Dockerhub repo digest as it was the first pushed
     DIST_REPO_DIGEST=$(docker image inspect --format '{{index .RepoDigests 0}}' ${BASENAME}:${DIST})
     update_minideb_derived "https://github.com/bitnami/minideb-extras" $DIST $DIST_REPO_DIGEST
-    update_minideb_derived "https://github.com/bitnami/minideb-extras-base" $DIST $DIST_REPO_DIGEST
     update_minideb_derived "https://github.com/bitnami/minideb-runtimes" $DIST $DIST_REPO_DIGEST
 done
+
+# Create and merge a PR to update minideb-extras-base
+update_minideb_derived "https://github.com/bitnami/minideb-extras-base" "stretch" $DIST_REPO_DIGEST


### PR DESCRIPTION
In order to prevent errors during the update of minideb derived images, we will update extras-base in a different stage