### PR TITLE
Fix pushall script

### DIFF
--- a/pushall
+++ b/pushall
@@ -27,7 +27,7 @@ fi
 
 if [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE:-}" -a -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY:-}" ]; then
     tmpdir=$(mktemp -d)
-    bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" > "${tmpdir}/key"'
+    (cd "${tmpdir}" && bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" > key')
     docker trust key load "${tmpdir}/key"
     rm -rf "${tmpdir}"
     export DOCKER_CONTENT_TRUST=1    


### PR DESCRIPTION
The code tries to avoid the contents to be printed in the output in case the shell tracing is enabled at some point, but that implementation also makes the `tmpdir` variable not to be accessible in that context.