### PR TITLE
fix key permissions

### DIFF
--- a/pushall
+++ b/pushall
@@ -28,6 +28,7 @@ fi
 if [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE:-}" -a -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY:-}" ]; then
     tmpdir=$(mktemp -d)
     (cd "${tmpdir}" && bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" > key')
+    chmod 400 "${tmpdir}/key"
     docker trust key load "${tmpdir}/key"
     rm -rf "${tmpdir}"
     export DOCKER_CONTENT_TRUST=1    


### PR DESCRIPTION
We found this issue in the [travis-ci build](https://travis-ci.org/bitnami/minideb/jobs/430738346#L5162):

```
refusing to load key from /tmp/tmp.7IS3P9lCpg/key: private key file /tmp/tmp.7IS3P9lCpg/key must not be readable or writable by others
```

Making the file readable by the running user should fix the problem