### PR TITLE
Decode key value

### DIFF
--- a/pushall
+++ b/pushall
@@ -27,7 +27,7 @@ fi
 
 if [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE:-}" -a -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY:-}" ]; then
     tmpdir=$(mktemp -d)
-    (cd "${tmpdir}" && bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" | base64 -D > key')
+    (cd "${tmpdir}" && bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" | base64 -d > key')
     chmod 400 "${tmpdir}/key"
     docker trust key load "${tmpdir}/key"
     rm -rf "${tmpdir}"

--- a/pushall
+++ b/pushall
@@ -27,7 +27,7 @@ fi
 
 if [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE:-}" -a -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY:-}" ]; then
     tmpdir=$(mktemp -d)
-    (cd "${tmpdir}" && bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" > key')
+    (cd "${tmpdir}" && bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" | base64 -D > key')
     chmod 400 "${tmpdir}/key"
     docker trust key load "${tmpdir}/key"
     rm -rf "${tmpdir}"


### PR DESCRIPTION
The docker content trust repository key is base64-encoded, so let's decode it before dumping it to a file