### PR TITLE
Enable content trust only when pushing to DockerHub

### DIFF
--- a/pushall
+++ b/pushall
@@ -25,17 +25,18 @@ if [ -n "${GCR_KEY:-}" ]; then
     gcloud auth activate-service-account "$GCR_EMAIL" --key-file <(echo "$GCR_KEY")
 fi
 
+ENABLE_DOCKER_CONTENT_TRUST=0
 if [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE:-}" -a -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY:-}" ]; then
     tmpdir=$(mktemp -d)
     (cd "${tmpdir}" && bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" | base64 -d > key')
     chmod 400 "${tmpdir}/key"
     docker trust key load "${tmpdir}/key"
     rm -rf "${tmpdir}"
-    export DOCKER_CONTENT_TRUST=1    
+    export ENABLE_DOCKER_CONTENT_TRUST=1
 fi
 
 for DIST in $DISTS; do
-    docker push "${BASENAME}:${DIST}"
+    DOCKER_CONTENT_TRUST=${ENABLE_DOCKER_CONTENT_TRUST} docker push "${BASENAME}:${DIST}"
     docker push "${QUAY_BASENAME}:${DIST}"
     gcloud docker -- push "${GCR_BASENAME}:${DIST}"
 done


### PR DESCRIPTION
The result of pushing to GCR or Quay.io with content trust enabled is unknown, so I rather avoid it for now.