### PR TITLE
Set buster as latest

### DIFF
--- a/buildall
+++ b/buildall
@@ -38,7 +38,7 @@ stretch
 buster
 unstable
 "
-LATEST=stretch
+LATEST=buster
 
 BASENAME=bitnami/minideb
 GCR_BASENAME=gcr.io/bitnami-containers/minideb


### PR DESCRIPTION
Buster is the latest Debian release, so point the `latest` tag to it.