### PR TITLE
Use deb.debian.org

### DIFF
--- a/mkimage
+++ b/mkimage
@@ -40,7 +40,7 @@ echo "Building base in $rootfsDir"
 DEBOOTSTRAP_DIR=$DEBOOTSTRAP_DIR debootstrap --keyring $KEYRING --variant container --foreign ${DIST} "$rootfsDir"
 chroot "$rootfsDir" bash debootstrap/debootstrap --second-stage
 
-echo -e "deb http://httpredir.debian.org/debian $DIST main" > "$rootfsDir/etc/apt/sources.list"
+echo -e "deb http://deb.debian.org/debian $DIST main" > "$rootfsDir/etc/apt/sources.list"
 if [ "$DIST" != "unstable" ]; then
     echo "deb http://security.debian.org/ $DIST/updates main" >> "$rootfsDir/etc/apt/sources.list"
 fi


### PR DESCRIPTION
The httpredir.debian.org service has been dropped in favour of deb.debian.org

ref: https://lists.debian.org/debian-mirrors/2017/02/msg00000.html