### PR TITLE
Fix reproducible builds by fixing date in /etc/shadow

### DIFF
--- a/mkimage
+++ b/mkimage
@@ -197,6 +197,11 @@ rm -r /var/lib/apt/lists /var/cache/apt/archives
 EOF
 chmod 0755 "$rootfsDir/usr/sbin/install_packages"
 
+# Set the password change date to a fixed date, otherwise it defaults to the current
+# date, so we get a different image every day. SOURCE_DATE_EPOCH is designed to do this, but
+# was only implemented recently, so we can't rely on it for all versions we want to build
+# We also have to copy over the backup at /etc/shadow- so that it doesn't change
+chroot "$rootfsDir" getent passwd | cut -d: -f1 | xargs -n 1 chroot "$rootfsDir" chage -d 17885 && cp "$rootfsDir/etc/shadow" "$rootfsDir/etc/shadow-"
 
 # Capture the most recent date that a package in the image was changed.
 # We don't care about the particular date, or which package it comes from,

--- a/test
+++ b/test
@@ -60,3 +60,14 @@ fi
 # See https://github.com/bitnami/minideb/issues/16
 desc "Check that we can install mysql-server (#16)"
 test install_packages $MYSQL_PACKAGE
+
+function shadow_check() {
+    local path=$1
+    test bash -c "(! cut -d: -f3 < $path | grep -v 17885 >/dev/null) || (cat $path && false)"
+}
+
+desc "Check that all users have a fixed day as the last password change date in /etc/shadow"
+shadow_check /etc/shadow
+
+desc "Check that all users have a fixed day as the last password change date in /etc/shadow-"
+shadow_check /etc/shadow-


### PR DESCRIPTION
The builds were reproducible provided they were done on the same day.

However if they were done on different days they had different dates
in /etc/shadow and so changed. This meant that the images were
updated every day, and sometimes the reproducibility check would
fail if the day ticked over between the builds.