### PR TITLE
[buildone] fix mistaken use of continue

### DIFF
--- a/buildone
+++ b/buildone
@@ -88,7 +88,7 @@ build() {
             built_image_id="$(./import build/$DIST.tar "$current_ts")"
         else
             log "Image didn't change"
-            continue
+            return
         fi
     fi
     docker tag $built_image_id $BASENAME:$DIST


### PR DESCRIPTION
When I moved this code in to its own script, I moved it
out of a loop, so we can no longer `continue` and should
`return` instead.