### PR TITLE
Tag other registries in push

### DIFF
--- a/buildone
+++ b/buildone
@@ -34,8 +34,6 @@ set -u
 set -o pipefail
 
 BASENAME=bitnami/minideb
-GCR_BASENAME=gcr.io/bitnami-containers/minideb
-QUAY_BASENAME=quay.io/bitnami/minideb
 
 LATEST=buster
 
@@ -92,13 +90,9 @@ build() {
         fi
     fi
     docker tag "$built_image_id" "$BASENAME:$DIST"
-    docker tag "$built_image_id" "$QUAY_BASENAME:$DIST"
-    docker tag "$built_image_id" "$GCR_BASENAME:$DIST"
-    log "Tagged $built_image_id as $BASENAME:$DIST $QUAY_BASENAME:$DIST $GCR_BASENAME:$DIST"
+    log "Tagged $built_image_id as $BASENAME:$DIST"
     if [ "$DIST" == "$LATEST" ]; then
         docker tag "$BASENAME:$DIST" "$BASENAME:latest"
-        docker tag "$QUAY_BASENAME:$DIST" "$QUAY_BASENAME:latest"
-        docker tag "$GCR_BASENAME:$DIST" "$GCR_BASENAME:latest"
     fi
 }
 

--- a/pushall
+++ b/pushall
@@ -38,6 +38,8 @@ fi
 
 for DIST in $DISTS; do
     DOCKER_CONTENT_TRUST=${ENABLE_DOCKER_CONTENT_TRUST} docker push "${BASENAME}:${DIST}"
+    docker tag "${BASENAME}:${DIST}" "${QUAY_BASENAME}:${DIST}"
+    docker tag "${BASENAME}:${DIST}" "${GCR_BASENAME}:${DIST}"
     docker push "${QUAY_BASENAME}:${DIST}"
     gcloud docker -- push "${GCR_BASENAME}:${DIST}"
 done


### PR DESCRIPTION
Previously we were tagging for all registries as we built
the images and then pushing all registries blindly.

Now if an image hasn't changed it wouldn't tag with the other
registry tags, and then the push would fail as the gcr/quay
tags didn't exist.

Rather than taking care to tag in the case where the image
hasn't changed, instead change the pushall script to
only assume that `bitnami/minideb` tags are correct, and
tag the other registries based on that one before pushing.

This ensures that the tags will always exist, and also makes
sure we are pushing the same image to each registry (excluding
race conditions.)