### PR TITLE
Don't delete symlinks in /usr/share/doc

### DIFF
--- a/mkimage
+++ b/mkimage
@@ -221,7 +221,12 @@ done
 # Remove the aux-cache as it isn't reproducible. It doesn't seem to
 # cause any problems to remove it.
 rm "$rootfsDir/var/cache/ldconfig/aux-cache"
-find "$rootfsDir/usr/share/doc" -mindepth 1 -not -name copyright -not -type d -delete
+# Remove /usr/share/doc, but leave copyright files to be sure that we
+# comply with all licenses.
+# `mindepth 2` as we only want to remove files within the per-package
+# directories. Crucially some packages use a symlink to another package
+# dir (e.g. libgcc1), and we don't want to remove those.
+find "$rootfsDir/usr/share/doc" -mindepth 2 -not -name copyright -not -type d -delete
 find "$rootfsDir/usr/share/doc" -mindepth 1 -type d -empty -delete
 # Set the mtime on all files to be no older than $BUILD_DATE.
 # This is required to have the same metadata on files so that the


### PR DESCRIPTION
/usr/share/doc contains a structure that might be like

```
   foo/copyright
   foo/other
   bar -> foo
```

In this case we want to delete `foo/other`, but leave `bar` alone.

The previous code would delete `bar` as it is not a directory.

However, the structure of `/usr/share/doc` is such that the first
level is a per-package directory (or symlink) and the directory
contains the files. We therefore want to only consider files in the
package directories, so look a level further down the tree before
deleting.