### PR TITLE
Stop trying to update -extras

### DIFF
--- a/pushall
+++ b/pushall
@@ -63,7 +63,5 @@ source <(curl -sSL "$CIRCLE_CI_FUNCTIONS_URL")
 for DIST in $DISTS; do
     # Use '.RepoDigests 0' for getting Dockerhub repo digest as it was the first pushed
     DIST_REPO_DIGEST=$(docker image inspect --format '{{index .RepoDigests 0}}' "${BASENAME}:${DIST}")
-    update_minideb_derived "https://github.com/bitnami/minideb-extras" "$DIST" "$DIST_REPO_DIGEST"
-    update_minideb_derived "https://github.com/bitnami/minideb-extras-base" "$DIST" "$DIST_REPO_DIGEST"
     update_minideb_derived "https://github.com/bitnami/minideb-runtimes" "$DIST" "$DIST_REPO_DIGEST"
 done


### PR DESCRIPTION
The -extras repos are archived, so we can't create PRs any more, so don't try.

-runtimes is still active.