### PR TITLE
fix: disable unstable

### DIFF
--- a/buildall
+++ b/buildall
@@ -9,7 +9,6 @@ set -o pipefail
 dist="jessie
 stretch
 buster
-unstable
 "
 dist_with_snapshot="buster"
 


### PR DESCRIPTION
As previously researched in #86, there is some upstream issue with `util-linux` when building `unstable` distribution. 

This PR disable `minideb/unstable` building entry until the issue was solved so we can release the latest version for the rest of the distributions.  
