### PR TITLE
fix: not try to publish unstable distro

### DIFF
--- a/pushall
+++ b/pushall
@@ -7,7 +7,6 @@ set -o pipefail
 DISTS="jessie
 stretch
 buster
-unstable
 "
 DISTS_WITH_SNAPSHOT="buster"
 LATEST=buster


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

As previously researched in #86, there is some upstream issue with util-linux when building unstable distribution.

This PR disable minideb/unstable publishing entry until the issue was solved so we can release and publish the latest version for the rest of the distributions.