### PR TITLE
arm64 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
+.kvm-images
 .installed-requirements
+.installed-qemu
 namibase/nami-linux-x64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,77 @@
 language: bash
-sudo: required
-script: bash shellcheck && sudo bash buildall
-dist: xenial
+dist: focal
+virt: vm
+group: edge
+os: linux
 services:
   - docker
-before_install:
-  - docker version
-  # Fix for Ubuntu Xenial apt-daily.service triggering
-  # https://unix.stackexchange.com/questions/315502/how-to-disable-apt-daily-service-on-ubuntu-cloud-vm-image
-  - |
-    while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do
-      sleep 1
-    done
-  - sudo apt-get -qq update
-  - sudo apt-get install -y debian-archive-keyring debootstrap shellcheck
-deploy:
-  provider: script
-  script: bash pushall
-  skip_cleanup: true
-  on:
-    branch: master
+
+.build_job: &build_job
+  stage: build
+  before_install:
+    - docker version
+    # Fix for Ubuntu Xenial apt-daily.service triggering
+    # https://unix.stackexchange.com/questions/315502/how-to-disable-apt-daily-service-on-ubuntu-cloud-vm-image
+    - |
+      while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do
+        sleep 1
+      done
+    - sudo rm /usr/local/bin/jq
+  install:
+    - sudo make .installed-requirements
+  script: sudo bash buildone $DIST $PLATFORM
+  after_success:
+    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo docker tag "bitnami/minideb:$DIST-$PLATFORM" "$BASENAME:latest-$PLATFORM" ; fi'
+    - 'if [[ "$TRAVIS_BRANCH" == "master" ]] ; then sudo bash pushone $DIST $PLATFORM ; fi'
+    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo bash pushone latest $PLATFORM ; fi'
+
+jobs:
+  include:
+    - stage: shellcheck
+      install:
+        - sudo apt-get -qq update
+        - sudo apt-get install -y shellcheck
+      script: bash shellcheck
+    - <<: *build_job
+      arch: amd64
+      env:
+        - DIST=jessie PLATFORM=amd64
+    - <<: *build_job
+      arch: amd64
+      env:
+        - DIST=stretch PLATFORM=amd64
+    - <<: *build_job
+      arch: amd64
+      env:
+        - DIST=buster PLATFORM=amd64
+    - <<: *build_job
+      arch: arm64-graviton2
+      env:
+        - DIST=stretch PLATFORM=arm64
+    - <<: *build_job
+      arch: arm64-graviton2
+      env:
+        - DIST=buster PLATFORM=arm64
+    - stage: deploy
+      if: branch = master AND type = push
+      env:
+        - DISTS="stretch buster latest"
+      before_install: mkdir $HOME/.docker
+      install: 'echo "{ \"experimental\": \"enabled\" }" > $HOME/.docker/config.json'
+      script:
+        - |
+          if [ -n "${DOCKER_PASSWORD:-}" ]; then
+              docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+          fi
+
+          # Create and merge a PR to update minideb-extras
+          CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
+          source <(curl -sSL "$CIRCLE_CI_FUNCTIONS_URL")
+          for DIST in $DISTS; do
+            sudo docker manifest create bitnami/minideb:$DIST bitnami/minideb:$DIST-amd64 bitnami/minideb:$DIST-arm64
+            sudo docker manifest push bitnami/minideb:$DIST
+
+            # Use '.RepoDigests 0' for getting Dockerhub repo digest as it was the first pushed
+            DIST_REPO_DIGEST=$(docker image inspect --format '{{index .RepoDigests 0}}' "${BASENAME}:${DIST}")
+            update_minideb_derived "https://github.com/bitnami/minideb-runtimes" "$DIST" "$DIST_REPO_DIGEST"
+          done

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,13 @@ services:
     - sudo rm /usr/local/bin/jq
   install:
     - sudo make .installed-requirements
-  script: sudo bash buildone $DIST $PLATFORM
+  script:
+    - sudo bash buildone $DIST $PLATFORM
+    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo bash buildone_snapshot $DIST "$(./snapshot_id)" $PLATFORM ; fi'
   after_success:
     - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo docker tag "bitnami/minideb:$DIST-$PLATFORM" "$BASENAME:latest-$PLATFORM" ; fi'
     - 'if [[ "$TRAVIS_BRANCH" == "master" ]] ; then sudo bash pushone $DIST $PLATFORM ; fi'
+    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo bash pushone "buster-$(./snapshot_id)" $PLATFORM ; fi'
     - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo bash pushone latest $PLATFORM ; fi'
 
 jobs:
@@ -45,11 +48,11 @@ jobs:
       env:
         - DIST=buster PLATFORM=amd64
     - <<: *build_job
-      arch: arm64-graviton2
+      arch: arm64
       env:
         - DIST=stretch PLATFORM=arm64
     - <<: *build_job
-      arch: arm64-graviton2
+      arch: arm64
       env:
         - DIST=buster PLATFORM=arm64
     - stage: deploy
@@ -67,7 +70,7 @@ jobs:
           # Create and merge a PR to update minideb-extras
           CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
           source <(curl -sSL "$CIRCLE_CI_FUNCTIONS_URL")
-          for DIST in $DISTS; do
+          for DIST in "$DISTS buster-$(./snapshot_id)"; do
             sudo docker manifest create bitnami/minideb:$DIST bitnami/minideb:$DIST-amd64 bitnami/minideb:$DIST-arm64
             sudo docker manifest push bitnami/minideb:$DIST
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,11 @@ jobs:
       env:
         - DIST=buster PLATFORM=amd64
     - <<: *build_job
-      arch: arm64
+      arch: arm64-graviton2
       env:
         - DIST=stretch PLATFORM=arm64
     - <<: *build_job
-      arch: arm64
+      arch: arm64-graviton2
       env:
         - DIST=buster PLATFORM=arm64
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,16 +79,35 @@ jobs:
           for DIST in $DISTS ; do
             sudo docker manifest create $BASENAME:$DIST $BASENAME:$DIST-amd64 $BASENAME:$DIST-arm64
             sudo docker manifest push $BASENAME:$DIST
-            sudo docker pull $BASENAME:$DIST
 
             if [[ "$DISTS_WITH_SNAPSHOT" =~ (^|[[:space:]])"$DIST"($|[[:space:]]) ]] ; then
               SNAPSHOT_NAME="$DIST-snapshot-$(./snapshot_id)"
-              sudo docker manifest create $SNAPSHOT_NAME:$DIST $SNAPSHOT_NAME:$DIST-amd64 $SNAPSHOT_NAME:$DIST-arm64
-              sudo docker manifest push $SNAPSHOT_NAME:$DIST
-              sudo docker pull $SNAPSHOT_NAME:$DIST
+              sudo docker manifest create $BASENAME:$SNAPSHOT_NAME $BASENAME:$SNAPSHOT_NAME-amd64 $BASENAME:$SNAPSHOT_NAME-arm64
+              sudo docker manifest push $BASENAME:$SNAPSHOT_NAME
             fi
 
             # Use '.RepoDigests 0' for getting Dockerhub repo digest as it was the first pushed
-            DIST_REPO_DIGEST=$(docker image inspect --format '{{index .RepoDigests 0}}' "$BASENAME:${DIST}")
+            DIST_REPO_DIGEST="$BASENAME"@$(docker manifest inspect "$BASENAME:${DIST}" | jq -r .manifests[0].digest)
             update_minideb_derived "https://github.com/$BASENAME-runtimes" "$DIST" "$DIST_REPO_DIGEST"
           done
+    - stage: deploy
+      if: branch = master AND type = push
+      env:
+        - DIST="jessie"
+      before_install: mkdir $HOME/.docker
+      install: 'echo "{ \"experimental\": \"enabled\" }" > $HOME/.docker/config.json'
+      script:
+        - |
+          if [ -n "${DOCKER_PASSWORD:-}" ]; then
+              docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+          fi
+
+          # Create and merge a PR to update minideb-extras
+          CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
+          source <(curl -sSL "$CIRCLE_CI_FUNCTIONS_URL")
+          sudo docker manifest create $BASENAME:$DIST $BASENAME:$DIST-amd64
+          sudo docker manifest push $BASENAME:$DIST
+
+          # Use '.RepoDigests 0' for getting Dockerhub repo digest as it was the first pushed
+          DIST_REPO_DIGEST="$BASENAME"@$(docker manifest inspect "$BASENAME:${DIST}" | jq -r .manifests[0].digest)
+          update_minideb_derived "https://github.com/$BASENAME-runtimes" "$DIST" "$DIST_REPO_DIGEST"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ services:
   - docker
 
 env:
-  - BASENAME=bitnami/minideb
+  global:
+    - BASENAME=bitnami/minideb
+    - LATEST=buster
+    - DISTS_WITH_SNAPSHOT="$LATEST"
 
 .build_job: &build_job
   stage: build
@@ -24,12 +27,12 @@ env:
     - sudo make .installed-requirements
   script:
     - sudo bash buildone $DIST $PLATFORM
-    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo bash buildone_snapshot $DIST "$(./snapshot_id)" $PLATFORM ; fi'
+    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DISTS_WITH_SNAPSHOT" =~ (^|[[:space:]])"$DIST"($|[[:space:]]) ]] ; then sudo bash buildone_snapshot $DIST "$(./snapshot_id)" $PLATFORM ; fi'
   after_success:
-    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo docker tag "$BASENAME:$DIST-$PLATFORM" "$BASENAME:latest-$PLATFORM" ; fi'
+    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$LATEST" == "$DIST" ]] ; then sudo docker tag "$BASENAME:$DIST-$PLATFORM" "$BASENAME:latest-$PLATFORM" ; fi'
     - 'if [[ "$TRAVIS_BRANCH" == "master" ]] ; then sudo bash pushone $DIST $PLATFORM ; fi'
-    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo bash pushone "buster-$(./snapshot_id)" $PLATFORM ; fi'
-    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo bash pushone latest $PLATFORM ; fi'
+    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DISTS_WITH_SNAPSHOT" =~ (^|[[:space:]])"$DIST"($|[[:space:]]) ]] ; then sudo bash pushone "$DIST-snapshot-$(./snapshot_id)" $PLATFORM ; fi'
+    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$LATEST" == "$DIST" ]] ; then sudo bash pushone latest $PLATFORM ; fi'
 
 jobs:
   include:
@@ -73,9 +76,17 @@ jobs:
           # Create and merge a PR to update minideb-extras
           CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
           source <(curl -sSL "$CIRCLE_CI_FUNCTIONS_URL")
-          for DIST in $DISTS buster-$(./snapshot_id); do
+          for DIST in $DISTS ; do
             sudo docker manifest create $BASENAME:$DIST $BASENAME:$DIST-amd64 $BASENAME:$DIST-arm64
             sudo docker manifest push $BASENAME:$DIST
+            sudo docker pull $BASENAME:$DIST
+
+            if [[ "$DISTS_WITH_SNAPSHOT" =~ (^|[[:space:]])"$DIST"($|[[:space:]]) ]] ; then
+              SNAPSHOT_NAME="$DIST-snapshot-$(./snapshot_id)"
+              sudo docker manifest create $SNAPSHOT_NAME:$DIST $SNAPSHOT_NAME:$DIST-amd64 $SNAPSHOT_NAME:$DIST-arm64
+              sudo docker manifest push $SNAPSHOT_NAME:$DIST
+              sudo docker pull $SNAPSHOT_NAME:$DIST
+            fi
 
             # Use '.RepoDigests 0' for getting Dockerhub repo digest as it was the first pushed
             DIST_REPO_DIGEST=$(docker image inspect --format '{{index .RepoDigests 0}}' "$BASENAME:${DIST}")

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ os: linux
 services:
   - docker
 
+env:
+  - BASENAME=bitnami/minideb
+
 .build_job: &build_job
   stage: build
   before_install:
@@ -23,7 +26,7 @@ services:
     - sudo bash buildone $DIST $PLATFORM
     - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo bash buildone_snapshot $DIST "$(./snapshot_id)" $PLATFORM ; fi'
   after_success:
-    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo docker tag "bitnami/minideb:$DIST-$PLATFORM" "$BASENAME:latest-$PLATFORM" ; fi'
+    - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo docker tag "$BASENAME:$DIST-$PLATFORM" "$BASENAME:latest-$PLATFORM" ; fi'
     - 'if [[ "$TRAVIS_BRANCH" == "master" ]] ; then sudo bash pushone $DIST $PLATFORM ; fi'
     - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo bash pushone "buster-$(./snapshot_id)" $PLATFORM ; fi'
     - 'if [[ "$TRAVIS_BRANCH" == "master" && "$DIST" == "buster" ]] ; then sudo bash pushone latest $PLATFORM ; fi'
@@ -71,10 +74,10 @@ jobs:
           CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
           source <(curl -sSL "$CIRCLE_CI_FUNCTIONS_URL")
           for DIST in $DISTS buster-$(./snapshot_id); do
-            sudo docker manifest create bitnami/minideb:$DIST bitnami/minideb:$DIST-amd64 bitnami/minideb:$DIST-arm64
-            sudo docker manifest push bitnami/minideb:$DIST
+            sudo docker manifest create $BASENAME:$DIST $BASENAME:$DIST-amd64 $BASENAME:$DIST-arm64
+            sudo docker manifest push $BASENAME:$DIST
 
             # Use '.RepoDigests 0' for getting Dockerhub repo digest as it was the first pushed
-            DIST_REPO_DIGEST=$(docker image inspect --format '{{index .RepoDigests 0}}' "bitnami/minideb:${DIST}")
-            update_minideb_derived "https://github.com/bitnami/minideb-runtimes" "$DIST" "$DIST_REPO_DIGEST"
+            DIST_REPO_DIGEST=$(docker image inspect --format '{{index .RepoDigests 0}}' "$BASENAME:${DIST}")
+            update_minideb_derived "https://github.com/$BASENAME-runtimes" "$DIST" "$DIST_REPO_DIGEST"
           done

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
       while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do
         sleep 1
       done
-    - sudo rm /usr/local/bin/jq
+    - sudo rm -f /usr/local/bin/jq
   install:
     - sudo make .installed-requirements
   script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,11 +70,11 @@ jobs:
           # Create and merge a PR to update minideb-extras
           CIRCLE_CI_FUNCTIONS_URL=${CIRCLE_CI_FUNCTIONS_URL:-https://raw.githubusercontent.com/bitnami/test-infra/master/circle/functions}
           source <(curl -sSL "$CIRCLE_CI_FUNCTIONS_URL")
-          for DIST in "$DISTS buster-$(./snapshot_id)"; do
+          for DIST in $DISTS buster-$(./snapshot_id); do
             sudo docker manifest create bitnami/minideb:$DIST bitnami/minideb:$DIST-amd64 bitnami/minideb:$DIST-arm64
             sudo docker manifest push bitnami/minideb:$DIST
 
             # Use '.RepoDigests 0' for getting Dockerhub repo digest as it was the first pushed
-            DIST_REPO_DIGEST=$(docker image inspect --format '{{index .RepoDigests 0}}' "${BASENAME}:${DIST}")
+            DIST_REPO_DIGEST=$(docker image inspect --format '{{index .RepoDigests 0}}' "bitnami/minideb:${DIST}")
             update_minideb_derived "https://github.com/bitnami/minideb-runtimes" "$DIST" "$DIST_REPO_DIGEST"
           done

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ clean:
 clobber: clean
 	@${RM} .installed-requirements
 
+.installed-qemu:
+	@echo "Installing QEMU and required packages..."
+	@./install-qemu.sh
+	@touch $@
+
 .installed-requirements:
 	@echo "Installing required packages..."
 	@./pre-build.sh

--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ To test the resulting image:
 $ sudo make test-stretch
 ```
 
+## Building Minideb for foreign architecture
+Make commands shown above will build an image for the architecture you are currently working on.  
+To build an image for a foreign architecture (for example to build a multiarch image), we provide a
+simple script which run a QEMU instance for the target architecture and build the image inside it.
+
+To build and test a buster image for arm64:
+```
+$ ./qemu_build buster arm64
+```
+
+The image will be then imported locally through the docker cli with `$distribution-$architecture` tag
+(example: `bitnami/minideb:buster-arm64`)
+
+Current limitations of `qemu_build` script:
+
+- Can be run only on debian-based distributions
+- Support `AMD64` and `ARM64` target architectures only
+
 # Contributing
 We'd love for you to contribute to this image. You can request new features by creating an [issue](https://github.com/bitnami/minideb/issues), or submit a [pull request](https://github.com/bitnami/minideb/pulls) with your contribution.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We provide a Makefile to help you build Minideb locally. It should be run on a D
 $ sudo make
 ```
 
-To build an individual release (stretch, jessie or unstable)
+To build an individual release (stretch, buster or unstable)
 ```
 $ sudo make stretch
 ```

--- a/buildall
+++ b/buildall
@@ -6,22 +6,32 @@ set -e
 set -u
 set -o pipefail
 
+arch=${1:-"amd64 arm64"}
+
 dist="jessie
 stretch
 buster
 "
 dist_with_snapshot="buster"
 
-for i in $dist; do
-    ./buildone "$i"
+for a in $arch; do
+  for i in $dist; do
+    if [[ "$a" != "amd64" && "$i" == "jessie" ]]; then
+      continue
+    fi
+
+    ./buildone "$i" "$a"
+  done
 done
 
 snapshot_id=$(./snapshot_id)
 if [ -n "$snapshot_id" ]; then
+  for a in $arch; do
     for i in $dist_with_snapshot; do
-        ./buildone_snapshot "$i" "$snapshot_id"
+        ./buildone_snapshot "$i" "$snapshot_id" "$a"
     done
 
-    mkdir -p build
-    echo "$snapshot_id" > build/snapshot_id
+    mkdir -p "build/$a"
+    echo "$snapshot_id" > "build/$a/snapshot_id"
+  done
 fi

--- a/buildone
+++ b/buildone
@@ -47,14 +47,14 @@ build() {
 
     debian_snapshot_id=${3:-}
     if [ -n "$debian_snapshot_id" ]; then
-        TAG="${DIST}-snapshot-${debian_snapshot_id}"
+        TAG="${DIST}-snapshot-${debian_snapshot_id}-$PLATFORM"
     else
-        TAG=$DIST
+        TAG=$DIST-$PLATFORM
     fi
 
     [ -f "debootstrap/$DIST" ] || (echo "buildall: Unknown distribution: $DIST" && exit 1)
     current_ts="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
-    if docker pull "$BASENAME:$TAG" > /dev/null; then
+    if docker pull "$BASENAME:$TAG-$PLATFORM" > /dev/null; then
         target_ts="$(docker inspect "$BASENAME:$TAG" | jq --raw-output ".[0].Created")"
         pulled_image_id="$(docker inspect "$BASENAME:$TAG" | jq --raw-output ".[0].Id")"
     else

--- a/buildone
+++ b/buildone
@@ -43,8 +43,9 @@ log() {
 
 build() {
     DIST=$1
+    PLATFORM=${2:-amd64}
 
-    debian_snapshot_id=${2:-}
+    debian_snapshot_id=${3:-}
     if [ -n "$debian_snapshot_id" ]; then
         TAG="${DIST}-snapshot-${debian_snapshot_id}"
     else
@@ -64,7 +65,7 @@ build() {
     log "Building $BASENAME:$TAG"
     log "============================================"
     ./mkimage "build/$TAG.tar" "$DIST" "${debian_snapshot_id:-}"
-    built_image_id=$(./import "build/$TAG.tar" "$target_ts")
+    built_image_id=$(./import "build/$TAG.tar" "$target_ts" "$PLATFORM")
     log "============================================"
     log "Running tests for $BASENAME:$TAG"
     log "============================================"
@@ -73,7 +74,7 @@ build() {
     log "Rebuilding $BASENAME:$TAG to test reproducibility"
     log "============================================"
     ./mkimage "build/${TAG}-repro.tar" "$DIST" "${debian_snapshot_id:-}"
-    repro_image_id=$(./import "build/${TAG}-repro.tar" "$target_ts")
+    repro_image_id=$(./import "build/${TAG}-repro.tar" "$target_ts" "$PLATFORM")
     if [ "$repro_image_id" != "$built_image_id" ]; then
         log "$BASENAME:$TAG differs after a rebuild. Examine $built_image_id and $repro_image_id"
         log "to find the differences and fix the build to be reproducible again."
@@ -89,14 +90,14 @@ build() {
             ./dockerdiff "$pulled_image_id" "$built_image_id" || true
             # Re-import with the current timestamp so that the image shows
             # as new
-            built_image_id="$(./import "build/$TAG.tar" "$current_ts")"
+            built_image_id="$(./import "build/$TAG.tar" "$current_ts" "$PLATFORM")"
         else
             log "Image didn't change"
             return
         fi
     fi
-    docker tag "$built_image_id" "$BASENAME:$TAG"
-    log "Tagged $built_image_id as $BASENAME:$TAG"
+    docker tag "$built_image_id" "$BASENAME:$TAG-$PLATFORM"
+    log "Tagged $built_image_id as $BASENAME:$TAG-$PLATFORM"
 }
 
 if [ -z "$1" ]; then
@@ -104,4 +105,4 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-build "${1}" "${2:-}"
+build "$@"

--- a/buildone_snapshot
+++ b/buildone_snapshot
@@ -6,5 +6,6 @@ set -o pipefail
 
 dist=${1:?dist arg is required}
 snapshot_id=${2:-$(./snapshot_id)}
+platform=${3:-amd64}
 
-./buildone "$dist" "$snapshot_id"
+./buildone "$dist" "$platform" "$snapshot_id"

--- a/import
+++ b/import
@@ -12,11 +12,12 @@ set -e
 set -u
 set -o pipefail
 
-CONF_TEMPLATE='{"architecture":"amd64","comment":"from Bitnami with love","config":{"Hostname":"","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":null,"Cmd":["/bin/bash"],"Image":"","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":null},"container_config":{"Hostname":"","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":null,"Cmd":null,"Image":"","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":null},"created":"%TIMESTAMP%","docker_version":"1.13.0","history":[{"created":"%TIMESTAMP%","comment":"from Bitnami with love"}],"os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:%LAYERSUM%"]}}'
-MANIFEST_TEMPLATE='[{"Config":"%CONF_SHA%.json","RepoTags":null,"Layers":["%LAYERSUM%/layer.tar"]}]'
-
 SOURCE=${1:?Specify the tarball to import}
 TIMESTAMP=${2:?Specify the timestamp to use}
+PLATFORM=${3:?Specify the target platform}
+
+CONF_TEMPLATE='{"architecture":"%PLATFORM%","comment":"from Bitnami with love","config":{"Hostname":"","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":null,"Cmd":["/bin/bash"],"Image":"","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":null},"container_config":{"Hostname":"","Domainname":"","User":"","AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":null,"Cmd":null,"Image":"","Volumes":null,"WorkingDir":"","Entrypoint":null,"OnBuild":null,"Labels":null},"created":"%TIMESTAMP%","docker_version":"1.13.0","history":[{"created":"%TIMESTAMP%","comment":"from Bitnami with love"}],"os":"linux","rootfs":{"type":"layers","diff_ids":["sha256:%LAYERSUM%"]}}'
+MANIFEST_TEMPLATE='[{"Config":"%CONF_SHA%.json","RepoTags":null,"Layers":["%LAYERSUM%/layer.tar"]}]'
 
 import() {
     local TDIR="$(mktemp -d)"
@@ -24,7 +25,7 @@ import() {
     mkdir $TDIR/$LAYERSUM
     cp $SOURCE $TDIR/$LAYERSUM/layer.tar
     echo -n '1.0' > $TDIR/$LAYERSUM/VERSION
-    local CONF="$(echo -n "$CONF_TEMPLATE" | sed -e "s/%TIMESTAMP%/$TIMESTAMP/g" -e "s/%LAYERSUM%/$LAYERSUM/g")"
+    local CONF="$(echo -n "$CONF_TEMPLATE" | sed -e "s/%PLATFORM%/$PLATFORM/g" -e "s/%TIMESTAMP%/$TIMESTAMP/g" -e "s/%LAYERSUM%/$LAYERSUM/g")"
     local CONF_SHA="$(echo -n "$CONF" | sha256sum | awk '{print $1}')"
     echo -n "$CONF" > "$TDIR/${CONF_SHA}.json"
     local MANIFEST="$(echo -n "$MANIFEST_TEMPLATE" | sed -e "s/%CONF_SHA%/$CONF_SHA/g" -e "s/%LAYERSUM%/$LAYERSUM/g")"

--- a/install-qemu.sh
+++ b/install-qemu.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eu
+
+do_sudo() {
+  if [[ "0" == "$(id --user)" ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+while do_sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do
+    sleep 1
+done
+
+do_sudo apt-get update
+do_sudo apt-get install -y qemu-kvm libvirt-bin qemu-utils genisoimage virtinst curl rsync qemu-system-x86 qemu-system-arm cloud-image-utils
+

--- a/pushone
+++ b/pushone
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+DIST=${1:?Specify the distrubution name}
+PLATFORM=${2:-amd64}
+
+BASENAME=bitnami/minideb
+GCR_BASENAME=gcr.io/bitnami-containers/minideb
+QUAY_BASENAME=quay.io/bitnami/minideb
+
+if [ -n "${DOCKER_PASSWORD:-}" ]; then
+    docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+fi
+
+if [ -n "${QUAY_PASSWORD:-}" ]; then
+    docker login -u "$QUAY_USERNAME" -p "$QUAY_PASSWORD" quay.io
+fi
+
+if [ -n "${GCR_KEY:-}" ]; then
+    gcloud auth activate-service-account "$GCR_EMAIL" --key-file <(echo "$GCR_KEY")
+fi
+
+ENABLE_DOCKER_CONTENT_TRUST=0
+if [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE:-}" ] && [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY:-}" ]; then
+    tmpdir=$(mktemp -d)
+    (cd "${tmpdir}" && bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" | base64 -d > key')
+    chmod 400 "${tmpdir}/key"
+    docker trust key load "${tmpdir}/key"
+    rm -rf "${tmpdir}"
+    export ENABLE_DOCKER_CONTENT_TRUST=1
+fi
+
+push() {
+    local dist="$1"
+    DOCKER_CONTENT_TRUST=${ENABLE_DOCKER_CONTENT_TRUST} docker push "${BASENAME}:${dist}"
+    docker push "${QUAY_BASENAME}:${dist}"
+    gcloud docker -- push "${GCR_BASENAME}:${dist}"
+}
+
+docker tag "${BASENAME}:${DIST}" "${QUAY_BASENAME}:${DIST}-${PLATFORM}"
+docker tag "${BASENAME}:${DIST}" "${GCR_BASENAME}:${DIST}-${PLATFORM}"
+push "$DIST-${PLATFORM}"
+

--- a/qemu_build
+++ b/qemu_build
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+BASENAME=bitnami/minideb
+pub_key_dir="$(mktemp -d)"
+
+do_ssh() {
+  ssh -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" root@localhost -t -p 5555 -i "$pub_key_dir/id_rsa" "$@"
+}
+
+finish() {
+  echo "Shutting down QEMU..."
+
+  n=0
+  until [ "$n" -ge 15 ]
+  do
+     do_ssh "true" && break
+     n=$((n+1))
+     sleep 30
+  done
+
+  do_ssh "poweroff" || true
+
+  sleep 5
+  n=0
+  until [ "$n" -ge 5 ]
+  do
+     kill -0 "$PID" && break
+     n=$((n+1))
+     sleep 5
+  done
+
+  kill -9 "$PID" || true
+  rm -f "$IMAGE_FILE" "$PIDFILE"
+}
+
+if [[ ! -f /etc/debian_version ]]; then
+  echo "minideb can currently only be built on debian based distros, aborting..."
+  exit 1
+fi
+
+if [ -z "$1" ]; then
+    echo "You must specify the dist to build"
+    exit 1
+fi
+
+DIST=$1
+PLATFORM=${2:-amd64}
+DEBIAN_SNAPSHOT_ID=${3:-}
+
+make .installed-qemu
+mkdir -p .kvm-images/{amd64,arm64}
+
+if [[ ! -f .kvm-images/amd64/buster-server-cloudimg-amd64.qcow2 && "$PLATFORM" == "amd64" ]]; then
+  curl -SL https://cdimage.debian.org/cdimage/openstack/current/debian-10-openstack-amd64.qcow2 > .kvm-images/amd64/buster-server-cloudimg-amd64.qcow2
+fi
+
+if [[ ! -f .kvm-images/arm64/buster-server-cloudimg-arm64.qcow2 && "$PLATFORM" == "arm64" ]]; then
+  curl -SL https://cdimage.debian.org/cdimage/openstack/current/debian-10-openstack-arm64.qcow2 > .kvm-images/arm64/buster-server-cloudimg-arm64.qcow2
+  curl -SL https://releases.linaro.org/components/kernel/uefi-linaro/latest/release/qemu64/QEMU_EFI.fd > .kvm-images/arm64/QEMU_EFI.fd
+fi
+
+IMAGE_FILE="build/$DIST/$PLATFORM/instance.qcow2"
+PIDFILE="build/$DIST/$PLATFORM/instance.pid"
+TARGET_FILE="build/$DIST/$PLATFORM/image.tar"
+
+mkdir -p "build/$DIST/$PLATFORM"
+
+qemu-img create -f qcow2 -o backing_file="../../../.kvm-images/$PLATFORM/buster-server-cloudimg-$PLATFORM.qcow2" "$IMAGE_FILE"
+qemu-img resize "$IMAGE_FILE" 8G
+
+USER_DATA='
+#cloud-config
+disable_root: false
+
+# USEFUL FOR DEBUG SSH CONNECTION ISSUES
+# chpasswd:
+#   list: |
+#     root:root
+#   expire: False
+
+users:
+    - name: root
+      ssh_authorized_keys:
+        - '
+
+cat /dev/zero | ssh-keygen -q -t rsa -f "$pub_key_dir/id_rsa" -N "" || true
+echo "$USER_DATA$(cat "$pub_key_dir/id_rsa.pub")" > "$pub_key_dir/user-data"
+
+cloud-localds "$pub_key_dir/user-data.img" "$pub_key_dir/user-data"
+
+case $PLATFORM in
+amd64)
+  qemu-system-x86_64 \
+    -enable-kvm \
+    -device virtio-net,netdev=net0 \
+    -netdev user,id=net0,hostfwd=tcp::5555-:22 \
+    -boot c \
+    -pidfile "$PIDFILE" \
+    -m 2G \
+    -drive "file=$IMAGE_FILE,format=qcow2" \
+    -drive "file=$pub_key_dir/user-data.img,format=raw" \
+    -vga none \
+    -nographic &
+  ;;
+arm64)
+  qemu-system-aarch64 \
+    -accel tcg,thread=multi \
+    -machine virt \
+    -cpu cortex-a57 \
+    -device virtio-net,netdev=net0 \
+    -netdev user,id=net0,hostfwd=tcp::5555-:22 \
+    -boot c \
+    -pidfile "$PIDFILE" \
+    -m 2G \
+    -monitor telnet::45454,server,nowait \
+    -bios .kvm-images/arm64/QEMU_EFI.fd  \
+    -drive "file=$IMAGE_FILE,format=qcow2" \
+    -drive "file=$pub_key_dir/user-data.img,format=raw" \
+    -vga none \
+    -nographic &
+  ;;
+esac
+
+trap finish EXIT
+
+sleep 30
+n=0
+until [ "$n" -ge 15 ]
+do
+   do_ssh "true" && break
+   n=$((n+1))
+   sleep 30
+done
+
+PID="$(cat "$PIDFILE")"
+
+do_ssh "apt-get update && apt-get install -y apt-transport-https make rsync ca-certificates curl gnupg-agent software-properties-common && mkdir /build"
+do_ssh "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -"
+do_ssh "add-apt-repository \"deb [arch=$PLATFORM] https://download.docker.com/linux/debian \$(lsb_release -cs) stable\""
+do_ssh "apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io"
+rsync -avz -e "ssh -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -p 5555 -i $pub_key_dir/id_rsa" --exclude ".git" --exclude ".installed-requirements" --exclude ".kvm-images" --exclude "build" --exclude "ssh" ./ "root@localhost:/build/."
+do_ssh "cd /build/ && make .installed-requirements"
+
+do_ssh "cd /build/ && ./buildone \"$DIST\" \"$PLATFORM\" \"$DEBIAN_SNAPSHOT_ID\""
+rsync -avz -e "ssh -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -p 5555 -i $pub_key_dir/id_rsa" "root@localhost:/build/build/$DIST.tar" "./$TARGET_FILE"
+
+current_ts="$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)"
+built_image_id=$(./import "$TARGET_FILE" "$current_ts" "$PLATFORM")
+docker tag "$built_image_id" "$BASENAME:$DIST-$PLATFORM"
+

--- a/test
+++ b/test
@@ -53,7 +53,7 @@ desc "Checking that the terminfo is valid when running with -t (#17)"
 echo "" | test_extra_args '-t' bash -c 'install_packages procps && top -d1 -n1 -b'
 
 MYSQL_PACKAGE=default-mysql-server
-if [ "jessie" == "$DIST" ]; then
+if [[ "$DIST" == "jessie"* ]]; then
     MYSQL_PACKAGE=mysql-server
 fi
 


### PR DESCRIPTION
Related to #76 

I needed arm based images for one of my work, so I modified the build scripts to build and push multiarch images to docker hub.
I'm publishing my work as a draft hoping that could be useful to support arm64 architecture.

The trickiest part was to test the build on my local environment, so I wrote the `qemu_build` script that installs qemu requirements, downloads the ubuntu image for the target platform and executes a build inside an emulated environment. It than exports the images into a tar, transfers it from the vm to the local environment and imports it as docker image with the right tag.
The script is not intended to run on CI environment like travis, as without KVM the build is very slow, but could be useful to test multi arch builds in local environments, or test new archs other than amd64 and arm64.

Hope this could help.