### PR TITLE
Include Debian 11 in CI automations

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -40,6 +40,37 @@ runs:
             echo "gcloud is installed"
         fi
       shell: bash
+    - name: "Install QEMU"
+      run: |
+        set -x
+        if [[ "${{ inputs.platform }}" == "arm64" ]]; then
+          echo "Installing QEMU"
+          # qemu-user-static fails with segfaults building bullseye
+          # We will revisit this when 20.10 is allowed as build slave on GitHub Actions
+          # https://bugs.launchpad.net/qemu/+bug/1749393
+          # https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1928075
+          if [[ "${{ inputs.dist }}" == "bullseye" ]]; then
+            sudo tee /etc/apt/preferences.d/qemu <<EOF
+        Package: *
+        Pin: release n=focal
+        Pin-Priority: 900
+        Package: *
+        Pin: release n=groovy
+        Pin-Priority: 400
+        EOF
+            sudo tee /etc/apt/sources.list.d/groovy.list <<EOF
+        deb http://archive.ubuntu.com/ubuntu groovy universe
+        deb http://archive.ubuntu.com/ubuntu groovy-updates universe
+        deb http://security.ubuntu.com/ubuntu groovy-security universe
+        EOF
+            sudo apt-get update -qq && sudo apt-get install -y -t groovy qemu-user-static
+          else
+            sudo apt-get update -qq && sudo apt-get install -y qemu-user-static
+          fi
+        else
+            echo "QEMU is not required for platform ${{ inputs.platform }}"
+        fi
+      shell: bash
     - name: Build snapshot id
       id: snapshot-id
       run: |
@@ -51,9 +82,6 @@ runs:
       run: |
         set -x
         echo Building  ${{ inputs.dist }} - ${{ inputs.platform }}
-        if [[ "${{ inputs.platform }}" == "arm64" ]]; then
-          sudo apt-get update -qq && sudo apt-get install -y qemu-user-static
-        fi
         sudo -E bash -x buildone "${{ inputs.dist }}" "${{ inputs.platform }}"
         if ${{ inputs.build_snapshot }} ; then
              sudo -E bash -x buildone_snapshot "${{ inputs.dist }}" "${{ steps.snapshot-id.outputs.snapshot-id }}" "${{ inputs.platform }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,10 +68,7 @@ jobs:
       matrix:
         dist: [stretch, buster, bullseye]
         arch: [amd64, arm64]
-        exclude:
-          # bullseye arm fails to debootstrap with qemu: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1928075
-          - dist: bullseye
-            arch: arm64
+
     name: Build ${{ matrix.dist }} on ${{ matrix.arch }}
     steps:
       - name: Check out repository
@@ -123,5 +120,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Push Manifests
         run: |
-          DISTS="stretch buster latest" bash pushmanifest
-          DISTS="jessie bullseye" PLATFORMS=amd64 bash pushmanifest
+          DISTS="stretch buster bullseye latest" bash pushmanifest
+          DISTS=jessie PLATFORMS=amd64 bash pushmanifest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,10 @@ jobs:
       matrix:
         dist: [stretch, buster, bullseye]
         arch: [amd64, arm64]
-
+        exclude:
+          # bullseye arm fails to debootstrap with qemu: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1928075
+          - dist: bullseye
+            arch: arm64
     name: Build ${{ matrix.dist }} on ${{ matrix.arch }}
     steps:
       - name: Check out repository
@@ -120,5 +123,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Push Manifests
         run: |
-          DISTS="stretch buster bullseye latest" bash pushmanifest
-          DISTS=jessie PLATFORMS=amd64 bash pushmanifest
+          DISTS="stretch buster latest" bash pushmanifest
+          DISTS="jessie bullseye" PLATFORMS=amd64 bash pushmanifest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
     needs: [ shellcheck ]
     strategy:
       matrix:
-        dist: [stretch, buster]
+        dist: [stretch, buster, bullseye]
         arch: [amd64, arm64]
 
     name: Build ${{ matrix.dist }} on ${{ matrix.arch }}
@@ -120,5 +120,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Push Manifests
         run: |
-          DISTS="stretch buster latest" bash pushmanifest
+          DISTS="stretch buster bullseye latest" bash pushmanifest
           DISTS=jessie PLATFORMS=amd64 bash pushmanifest

--- a/pushmanifest
+++ b/pushmanifest
@@ -6,6 +6,7 @@ set -o pipefail
 
 DISTS=${DISTS:-"stretch
 buster
+bullseye
 latest
 "}
 


### PR DESCRIPTION
This change includes Debian 11 (bullseye) as a platform to build, test and push automatically in our GitHub Actions
