### PR TITLE
Update build for arm64 bullseye

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -55,15 +55,15 @@ runs:
         Pin: release n=focal
         Pin-Priority: 900
         Package: *
-        Pin: release n=groovy
+        Pin: release n=hirsute
         Pin-Priority: 400
         EOF
-            sudo tee /etc/apt/sources.list.d/groovy.list <<EOF
-        deb http://archive.ubuntu.com/ubuntu groovy universe
-        deb http://archive.ubuntu.com/ubuntu groovy-updates universe
-        deb http://security.ubuntu.com/ubuntu groovy-security universe
+            sudo tee /etc/apt/sources.list.d/hirsute.list <<EOF
+        deb http://archive.ubuntu.com/ubuntu hirsute universe
+        deb http://archive.ubuntu.com/ubuntu hirsute-updates universe
+        deb http://security.ubuntu.com/ubuntu hirsute-security universe
         EOF
-            sudo apt-get update -qq && sudo apt-get install -y -t groovy qemu-user-static
+            sudo apt-get update -qq && sudo apt-get install -y -t hirsute qemu-user-static
           else
             sudo apt-get update -qq && sudo apt-get install -y qemu-user-static
           fi


### PR DESCRIPTION
**Description of the change**

Fix actual github actions for build arm64 bullseye image replacing old Groovy repository to use Hirsute version instead

**Benefits**

Keep image updated daily