### PR TITLE
Update Debian versions

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,7 +1,7 @@
 inputs:
   dist:
     description: 'Dist to build'
-    default: 'buster'
+    default: 'bullseye'
   platform:
     description: 'Platform to build'
     default: 'amd64'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
     - cron:  '0 0 * * *'
 env:
   BASENAME: bitnami/minideb
-  LATEST: buster
+  LATEST: bullseye
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -35,38 +35,13 @@ jobs:
       - name: Verify scripts with shellcheck
         run: |
           bash shellcheck
-  build_jessie:
-    runs-on: ubuntu-20.04
-    needs: [ shellcheck ]
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v2
-      - name: Use local build action
-        uses: ./.github/actions/build
-        with:
-          dist: "jessie"
-          platform: "amd64"
-      - name: Push
-        if: github.ref == 'refs/heads/master'
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          GCR_EMAIL: ${{ secrets.GCR_EMAIL }}
-          GCR_KEY: ${{ secrets.GCR_KEY }}
-          GCR_TOKEN: ${{ secrets.GCR_TOKEN }}
-          DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
-        run: |
-          bash pushone jessie amd64
 
   build_multiarch:
     runs-on: ubuntu-20.04
     needs: [ shellcheck ]
     strategy:
       matrix:
-        dist: [stretch, buster, bullseye]
+        dist: [buster, bullseye]
         arch: [amd64, arm64]
 
     name: Build ${{ matrix.dist }} on ${{ matrix.arch }}
@@ -104,7 +79,7 @@ jobs:
 
   deploy_manifests:
     runs-on: ubuntu-20.04
-    needs: [ build_multiarch, build_jessie ]
+    needs: [ build_multiarch ]
     if: github.ref == 'refs/heads/master'
     env:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -120,5 +95,4 @@ jobs:
       - uses: actions/checkout@v2
       - name: Push Manifests
         run: |
-          DISTS="stretch buster bullseye latest" bash pushmanifest
-          DISTS=jessie PLATFORMS=amd64 bash pushmanifest
+          DISTS="buster bullseye latest" bash pushmanifest

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ $ docker run --rm -it bitnami/minideb:latest
 
 There are [tags](https://hub.docker.com/r/bitnami/minideb/tags/) for the different Debian releases.
 ```
-$ docker run --rm -it bitnami/minideb:stretch
+$ docker run --rm -it bitnami/minideb:bullseye
 ```
 
 The images are built daily and have the security release enabled, so will contain any security updates released more than 24 hours ago.
 
 You can also use the images as a base for your own `Dockerfile`:
 ```
-FROM bitnami/minideb:stretch
+FROM bitnami/minideb:bullseye
 ```
 
 # Why use Minideb
@@ -62,28 +62,28 @@ We provide a Makefile to help you build Minideb locally. It should be run on a D
 $ sudo make
 ```
 
-To build an individual release (stretch, buster or unstable)
+To build an individual release (buster, bullseye or unstable)
 ```
-$ sudo make stretch
+$ sudo make bullseye
 ```
 
 To test the resulting image:
 ```
-$ sudo make test-stretch
+$ sudo make test-bullseye
 ```
 
 ## Building Minideb for foreign architecture
-Make commands shown above will build an image for the architecture you are currently working on.  
+Make commands shown above will build an image for the architecture you are currently working on.
 To build an image for a foreign architecture (for example to build a multiarch image), we provide a
 simple script which run a QEMU instance for the target architecture and build the image inside it.
 
-To build and test a buster image for arm64:
+To build and test a bullseye image for arm64:
 ```
-$ ./qemu_build buster arm64
+$ ./qemu_build bullseye arm64
 ```
 
 The image will be then imported locally through the docker cli with `$distribution-$architecture` tag
-(example: `bitnami/minideb:buster-arm64`)
+(example: `bitnami/minideb:bullseye-arm64`)
 
 Current limitations of `qemu_build` script:
 

--- a/buildall
+++ b/buildall
@@ -8,18 +8,13 @@ set -o pipefail
 
 arch=${1:-"amd64 arm64"}
 
-dist="jessie
-stretch
-buster
+dist="buster
+bullseye
 "
-dist_with_snapshot="buster"
+dist_with_snapshot="bullseye"
 
 for a in $arch; do
   for i in $dist; do
-    if [[ "$a" != "amd64" && "$i" == "jessie" ]]; then
-      continue
-    fi
-
     ./buildone "$i" "$a"
   done
 done

--- a/pushall
+++ b/pushall
@@ -4,12 +4,11 @@ set -e
 set -u
 set -o pipefail
 
-DISTS="jessie
-stretch
-buster
+DISTS="buster
+bullseye
 "
-DISTS_WITH_SNAPSHOT="buster"
-LATEST=buster
+DISTS_WITH_SNAPSHOT="bullseye"
+LATEST=bullseye
 BASENAME=bitnami/minideb
 GCR_BASENAME=gcr.io/bitnami-containers/minideb
 

--- a/pushmanifest
+++ b/pushmanifest
@@ -4,13 +4,12 @@ set -e
 set -u
 set -o pipefail
 
-DISTS=${DISTS:-"stretch
-buster
+DISTS=${DISTS:-"buster
 bullseye
 latest
 "}
 
-DISTS_WITH_SNAPSHOT=${DISTS_WITH_SNAPSHOT:-buster}
+DISTS_WITH_SNAPSHOT=${DISTS_WITH_SNAPSHOT:-bullseye}
 BASENAME=bitnami/minideb
 GCR_BASENAME=gcr.io/bitnami-containers/minideb
 PLATFORMS=${PLATFORMS:-amd64 arm64}

--- a/test
+++ b/test
@@ -76,9 +76,6 @@ desc "Checking that the terminfo is valid when running with -t (#17)"
 echo "" | test_extra_args '-t' bash -c 'install_packages procps && top -d1 -n1 -b'
 
 MYSQL_PACKAGE=default-mysql-server
-if [[ "$DIST" == "jessie"* ]]; then
-    MYSQL_PACKAGE=mysql-server
-fi
 
 # See https://github.com/bitnami/minideb/issues/16
 desc "Check that we can install mysql-server (#16)"


### PR DESCRIPTION
**Description of the change**
According to https://wiki.debian.org/LTS:
- Debian 8 Jessie is not supported since some time ago
- Debian 9 Stretch is going to be unsupported in 10 days
- Debian 10 Buster is going to be LTS
- Debian 11 Bullseye is the latest stable version

In this PR I am removing everything related to the deprecated versions (Debian 8 Jessie and Debian 9 Stretch) as well as converting Debian 11 Bullseye into the `latest`/default one