### PR TITLE
Use buster for minideb snapshot

### DIFF
--- a/buildall
+++ b/buildall
@@ -11,7 +11,7 @@ arch=${1:-"amd64 arm64"}
 dist="buster
 bullseye
 "
-dist_with_snapshot="bullseye"
+dist_with_snapshot="buster"
 
 for a in $arch; do
   for i in $dist; do

--- a/pushall
+++ b/pushall
@@ -7,7 +7,7 @@ set -o pipefail
 DISTS="buster
 bullseye
 "
-DISTS_WITH_SNAPSHOT="bullseye"
+DISTS_WITH_SNAPSHOT="buster"
 LATEST=bullseye
 BASENAME=bitnami/minideb
 GCR_BASENAME=gcr.io/bitnami-containers/minideb

--- a/pushmanifest
+++ b/pushmanifest
@@ -9,7 +9,7 @@ bullseye
 latest
 "}
 
-DISTS_WITH_SNAPSHOT=${DISTS_WITH_SNAPSHOT:-bullseye}
+DISTS_WITH_SNAPSHOT=${DISTS_WITH_SNAPSHOT:-buster}
 BASENAME=bitnami/minideb
 GCR_BASENAME=gcr.io/bitnami-containers/minideb
 PLATFORMS=${PLATFORMS:-amd64 arm64}


### PR DESCRIPTION
**Description of the change**

Revert from #124 the changes related to using Debian 11 bullseye for the snapshot image. There is an issue when building this image (see [GH action](https://github.com/bitnami/minideb/runs/6966804999?check_suite_focus=true)):
```
================================
TEST: Checking that a package can be installed with apt
================================
Get:1 http://snapshot.debian.org/archive/debian/20220620T085218Z bullseye InRelease [116 kB]
Ign:2 http://snapshot.debian.org/archive/debian/20220620T085218Z bullseye-updates InRelease
Get:3 http://snapshot.debian.org/archive/debian-security/20220620T085218Z bullseye-security InRelease [44.1 kB]
Err:4 http://snapshot.debian.org/archive/debian/20220620T085218Z bullseye-updates Release
  404  Not Found [IP: 185.17.185.185 80]
Get:5 http://snapshot.debian.org/archive/debian/20220620T085218Z bullseye/main arm64 Packages [10.9 MB]
Get:6 http://snapshot.debian.org/archive/debian-security/20220620T085218Z bullseye-security/main arm64 Packages [193 kB]
Reading package lists...
E: The repository 'http://snapshot.debian.org/archive/debian/20220620T085218Z bullseye-updates Release' does not have a Release file.
Error: Process completed with exit code 100.
```

There is not a `bullseye-updates/` as there is for buster at https://snapshot.debian.org/archive/debian/20220620T085218Z/zzz-dists/