### PR TITLE
WIP #129: Unable to build Minideb for ARM64 foreign architecture

### DIFF
--- a/install-qemu.sh
+++ b/install-qemu.sh
@@ -15,5 +15,5 @@ while do_sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/nu
 done
 
 do_sudo apt-get update
-do_sudo apt-get install -y qemu-kvm libvirt-bin qemu-utils genisoimage virtinst curl rsync qemu-system-x86 qemu-system-arm cloud-image-utils
+do_sudo apt-get install -y qemu-kvm libvirt-daemon-system libvirt-clients qemu-utils genisoimage virtinst curl rsync qemu-system-x86 qemu-system-arm cloud-image-utils
 


### PR DESCRIPTION
Changed libvirt-bin to libvirt-daemon-system libvirt-clients as
documented in https://lists.debian.org/debian-user/2016/11/msg00518.html

Signed-off-by: Bob Tanner <tanner@real-time.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Changed libvirt-bin to libvirt-daemon-system libvirt-clients as
documented in https://lists.debian.org/debian-user/2016/11/msg00518.html

**Benefits**
Lets the `qemu_build bullseye arm64` script install the correct libvirt packages. 

**Possible drawbacks**
Assumes all the libvirt package are available for arm64 

**Additional information**
This PR only fixes the libvirt-bin package not being found. I do not know if this PR will allow a foreign architecture to be built.
