### PR TITLE
Update CI runners to Ubuntu 22.04 and remove workaround for qemu.

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -31,30 +31,9 @@ runs:
         set -x
         if [[ "${{ inputs.platform }}" == "arm64" ]]; then
           echo "Installing QEMU"
-          # qemu-user-static fails with segfaults building bullseye
-          # We will revisit this when 20.10 is allowed as build slave on GitHub Actions
-          # https://bugs.launchpad.net/qemu/+bug/1749393
-          # https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1928075
-          if [[ "${{ inputs.dist }}" == "bullseye" ]]; then
-            sudo tee /etc/apt/preferences.d/qemu <<EOF
-        Package: *
-        Pin: release n=focal
-        Pin-Priority: 900
-        Package: *
-        Pin: release n=hirsute
-        Pin-Priority: 400
-        EOF
-            sudo tee /etc/apt/sources.list.d/hirsute.list <<EOF
-        deb http://archive.ubuntu.com/ubuntu hirsute universe
-        deb http://archive.ubuntu.com/ubuntu hirsute-updates universe
-        deb http://security.ubuntu.com/ubuntu hirsute-security universe
-        EOF
-            sudo apt-get update -qq && sudo apt-get install -y -t hirsute qemu-user-static
-          else
-            sudo apt-get update -qq && sudo apt-get install -y qemu-user-static
-          fi
+          sudo apt-get update -qq && sudo apt-get install -y qemu-user-static
         else
-            echo "QEMU is not required for platform ${{ inputs.platform }}"
+          echo "QEMU is not required for platform ${{ inputs.platform }}"
         fi
       shell: bash
     - name: Build snapshot id

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
   # This workflow contains a single job called "build"
   shellcheck:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Shellcheck
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -38,7 +38,7 @@ jobs:
           bash shellcheck
 
   build_multiarch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ shellcheck ]
     strategy:
       matrix:
@@ -74,7 +74,7 @@ jobs:
           fi
 
   deploy_manifests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ build_multiarch ]
     if: github.ref == 'refs/heads/master'
     env:


### PR DESCRIPTION
**Description of the change**

Update the GitHub Actions CI runners from Ubuntu 20.04 to 22.04 and remove the [workaround for installing a new enough version of qemu](https://github.com/bitnami/minideb/blame/32362b6/.github/actions/build/action.yml#L34). The version of qemu that comes with Ubuntu 22.04 is new enough that we no longer need that workaround.

CI builds and pushes to DockerHub succeed with this change.

Fixes #132. Builds were [failing](https://github.com/bitnami/minideb/runs/8027588256?check_suite_focus=true#step:3:167) because the CI job was trying to install qemu from the Ubuntu Hirsute repo, which [reached end-of-life](https://fridge.ubuntu.com/2022/01/21/ubuntu-21-04-hirsute-hippo-end-of-life-reached-on-january-20-2022/) and was finally deleted last month. The errors looked like:

```
E: The repository 'http://archive.ubuntu.com/ubuntu hirsute Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu hirsute-updates Release' does not have a Release file.
E: The repository 'http://security.ubuntu.com/ubuntu hirsute-security Release' does not have a Release file.
Error: Process completed with exit code 100.
```

Tested by [running the CI workflow on the forked repo](https://github.com/sengi/minideb/actions/runs/2934543524), with the [docker repo `BASENAME` monkeypatched](https://github.com/sengi/minideb/compare/ci-on-ubuntu-jammy...master) to point at [my DockerHub account](https://hub.docker.com/repository/docker/sengifluff/minideb) so that the GitHub Actions jobs have permissions to push to DockerHub without running on the Bitnami GitHub repo. The monkeypatch commit is only on the [default branch of the forked repo](https://github.com/sengi/minideb), not on this PR's branch.

**Possible drawbacks**

I'm not aware of any drawbacks to this yet, but please let me know if I've missed something.

**Applicable issues**

#132