### PR TITLE
ci(runners): upgrade runners to the next LTS

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -31,10 +31,6 @@ runs:
         set -x
         if [[ "${{ inputs.platform }}" == "arm64" ]]; then
           echo "Installing QEMU"
-          # qemu-user-static fails with segfaults building bullseye
-          # We will revisit this when 20.10 is allowed as build slave on GitHub Actions
-          # https://bugs.launchpad.net/qemu/+bug/1749393
-          # https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1928075
           sudo apt-get update -qq && sudo apt-get install -y qemu-user-static
         else
             echo "QEMU is not required for platform ${{ inputs.platform }}"

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -35,24 +35,7 @@ runs:
           # We will revisit this when 20.10 is allowed as build slave on GitHub Actions
           # https://bugs.launchpad.net/qemu/+bug/1749393
           # https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1928075
-          if [[ "${{ inputs.dist }}" == "bullseye" ]]; then
-            sudo tee /etc/apt/preferences.d/qemu <<EOF
-        Package: *
-        Pin: release n=focal
-        Pin-Priority: 900
-        Package: *
-        Pin: release n=hirsute
-        Pin-Priority: 400
-        EOF
-            sudo tee /etc/apt/sources.list.d/hirsute.list <<EOF
-        deb http://archive.ubuntu.com/ubuntu hirsute universe
-        deb http://archive.ubuntu.com/ubuntu hirsute-updates universe
-        deb http://security.ubuntu.com/ubuntu hirsute-security universe
-        EOF
-            sudo apt-get update -qq && sudo apt-get install -y -t hirsute qemu-user-static
-          else
-            sudo apt-get update -qq && sudo apt-get install -y qemu-user-static
-          fi
+          sudo apt-get update -qq && sudo apt-get install -y qemu-user-static
         else
             echo "QEMU is not required for platform ${{ inputs.platform }}"
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
   # This workflow contains a single job called "build"
   shellcheck:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Shellcheck
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -38,7 +38,7 @@ jobs:
           bash shellcheck
 
   build_multiarch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ shellcheck ]
     strategy:
       matrix:
@@ -74,7 +74,7 @@ jobs:
           fi
 
   deploy_manifests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ build_multiarch ]
     if: github.ref == 'refs/heads/master'
     env:


### PR DESCRIPTION
**Description of the change**

Replace `ubuntu-20.04` with `ubuntu-22.04` runners.
Also, remove the workaround for installing a newer version `qemu-user-static` for certain cases.

**Benefits**

We get rid of the workaround, which is no longer working due to Ubuntu 21.04 being deprecated.

**Possible drawbacks**

There are almost no customizations added to the base runners, but there may be some differences that could unexpectedly break the CI. However, we may be able to detect them in this PR's CI.