### PR TITLE
[bitnami/**] Adding the ability to assign to a team member of the containers triage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,33 @@
+# This workflow is built to manage the triage support by using GH issues.
+name: '[Support] Organize triage'
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+  pull_request_target:
+    types:
+      - reopened
+      - opened
+permissions:
+  repository-projects: write
+  issues: write
+
+# To fix the concurrency when for example more than one label is added
+concurrency:
+  group: ${{ github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  # For any opened or reopened issue, should be sent into Triage
+  send_to_board:
+    if: ${{ github.actor != 'bitnami-bot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign to a person to work on it
+        uses: pozil/auto-assign-issue@v1.9.0
+        with:
+          numOfAssignee: 1
+          removePreviousAssignees: false
+          teams: "containers-triage"
+          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -10,17 +10,11 @@ on:
       - reopened
       - opened
 permissions:
-  repository-projects: write
   issues: write
 
-# To fix the concurrency when for example more than one label is added
-concurrency:
-  group: ${{ github.run_id }}
-  cancel-in-progress: false
-
 jobs:
-  # For any opened or reopened issue, should be sent into Triage
-  send_to_board:
+  # For any opened or reopened issue, should be assign to a team member
+  team_assignation:
     if: ${{ github.actor != 'bitnami-bot' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Adding a new workflow to assign new (or reopened) issues/PRs to the Bitnami containers triage team.

**Benefits**

Bitnami team will be notified because team members will be assigned.

**Possible drawbacks**

None detected.

**Applicable issues**

All new issues.
