### PR TITLE
ci(snapshot_id): Fix URL escaping

### DIFF
--- a/snapshot_id
+++ b/snapshot_id
@@ -24,6 +24,7 @@ get_latest_debian_snapshot_id() {
     local -r snapshot_list_tmp_file="${snapshot_tmp_dir}/month-snapshots.html"
 
     ! month_query=$(get_latest_month_query) && return 1
+    month_query=${month_query/&amp;month=/&month=}
 
     curl -sSfL "https://snapshot.debian.org/archive/debian/$month_query" > "$snapshot_list_tmp_file"
 


### PR DESCRIPTION
**Description of the change**

Fixes the CI builds, whose error was being hidden by an incorrect output from the `snapshot_id` script.

**Benefits**

CI builds will succeed again

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

The script was extracting the URL query from the links on the main page, but the `&` character was URL encoded, which seems to have stopped working.