### PR TITLE
Bump actions/checkout version from v2 to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Dependencies
         run: |
           sudo apt-get -qq update
@@ -48,7 +48,7 @@ jobs:
     name: Build ${{ matrix.dist }} on ${{ matrix.arch }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use local build action
         id: build
         uses: ./.github/actions/build
@@ -83,7 +83,7 @@ jobs:
       DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
       DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Push Manifests
         run: |
           DISTS="buster bullseye latest" bash pushmanifest


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout

![Screenshot 2022-11-03 at 17 56 36](https://user-images.githubusercontent.com/13216600/199785384-fa57ff88-ac12-4ca4-964c-981c74abd83f.png)

According to the above warning, we should bump the `actions/checkout` version to `v3` everywhere in order to use the latest NodeJS version. Taking a look at the [_actions/checkout_ releases](https://github.com/actions/checkout/releases/tag/v3.0.0), the new node version is used from 3.0.0 on.