### PR TITLE
Add slack´s notification for not succeed executions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,3 +82,43 @@ jobs:
       - name: Push Manifests
         run: |
           DISTS="buster bullseye latest" bash pushmanifest
+
+  # If the CI Pipeline does not succeed we should notify the interested agents
+  slack-notif:
+    runs-on: ubuntu-22.04
+    needs: [ build_multiarch, deploy_manifests ]
+    if: always()
+    name: Notify unsuccessful CI run
+    steps:
+      - name: Notify in Slack channel
+        if: ${{ needs.build_multiarch.result != 'success' || needs.deploy_manifests.result != 'success' }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.CD_SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#CC0000",
+                  "fallback": "Unsuccessful bitnami/minideb CI pipeline",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*Unsuccessful `bitnami/minideb` CI pipeline*"
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "The CI pipeline for <${{ github.event.head_commit.url }}|bitnami/minideb@${{ github.event.head_commit.id }}> did not succeed. Check the related <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|action run> for more information."
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.CD_SLACK_BOT_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         if: ${{ needs.build_multiarch.result != 'success' || needs.deploy_manifests.result != 'success' }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: ${{ secrets.CD_SLACK_CHANNEL_ID }}
+          channel-id: C04E3CL1WP7
           payload: |
             {
               "attachments": [

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
   build_multiarch:
     runs-on: ubuntu-22.04
     needs: [ shellcheck ]
+    if: github.ref == 'refs/heads/master'
     strategy:
       matrix:
         dist: [buster, bullseye]
@@ -91,7 +92,7 @@ jobs:
     name: Notify unsuccessful CI run
     steps:
       - name: Notify in Slack channel
-        if: ${{ needs.build_multiarch.result != 'success' || needs.deploy_manifests.result != 'success' }}
+        if: always()
         uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: C04E3CL1WP7


### PR DESCRIPTION
**Description of the change**

Add Slack´s notifications in case of CI pipeline failures.

**Benefits**

Notification to be aware of failed pipelines.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

None
