### PR TITLE
[bitnami/*] ci: Configure Slack alerts for CI failures in bitnami/minideb

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,6 @@ jobs:
         if: ${{ needs.build_multiarch.result != 'success' || needs.deploy_manifests.result != 'success' }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
-          channel-id: ${{ secrets.CI_SLACK_CHANNEL_ID }}
           payload: |
             {
               "attachments": [
@@ -123,4 +122,4 @@ jobs:
               ]
             }
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.CI_SLACK_BOT_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URLs }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,27 +97,25 @@ jobs:
         uses: slackapi/slack-github-action@v1.23.0
         with:
           payload: |
-          {
-            "text": "*Unsuccessful `bitnami/minideb` CI pipeline*",
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*Unsuccessful `bitnami/minideb` CI pipeline*"
+            {
+              "text": "*Unsuccessful `bitnami/minideb` CI pipeline*",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Unsuccessful `bitnami/minideb` CI pipeline*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The CI pipeline for <${{ github.event.head_commit.url }}|bitnami/minideb@${{ github.event.head_commit.id }}> did not succeed. Check the related <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|action run> for more information."
+                  }
                 }
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "The CI pipeline for <${{ github.event.head_commit.url }}|bitnami/minideb@${{ github.event.head_commit.id }}> did not succeed. Check the related <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|action run> for more information."
-                }
-              }
-            ]
-          }
-
-
+              ]
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.TEST_CI_SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "The CI pipeline for <${{ github.event.head_commit.url }}|bitnami/minideb@${{ github.event.head_commit.id }}> did not succeed. Check the related <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|action run> for more information."
+                    "text": "The CI pipeline for `bitnami/minideb` did not succeed. Check the related <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|action run> for more information."
                   }
                 }
               ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,29 +97,27 @@ jobs:
         uses: slackapi/slack-github-action@v1.23.0
         with:
           payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#CC0000",
-                  "fallback": "Unsuccessful bitnami/minideb CI pipeline",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*Unsuccessful `bitnami/minideb` CI pipeline*"
-                      }
-                    },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "The CI pipeline for <${{ github.event.head_commit.url }}|bitnami/minideb@${{ github.event.head_commit.id }}> did not succeed. Check the related <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|action run> for more information."
-                      }
-                    }
-                  ]
+          {
+            "text": "*Unsuccessful `bitnami/minideb` CI pipeline*",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Unsuccessful `bitnami/minideb` CI pipeline*"
                 }
-              ]
-            }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "The CI pipeline for <${{ github.event.head_commit.url }}|bitnami/minideb@${{ github.event.head_commit.id }}> did not succeed. Check the related <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|action run> for more information."
+                }
+              }
+            ]
+          }
+
+
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.TEST_CI_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,4 +122,4 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URLs }}
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,3 +82,43 @@ jobs:
       - name: Push Manifests
         run: |
           DISTS="buster bullseye latest" bash pushmanifest
+
+  # If the CI Pipeline does not succeed we should notify the interested agents
+  slack-notif:
+    runs-on: ubuntu-22.04
+    needs:
+      - build_multiarch
+      - deploy_manifests
+    if: always()
+    name: Notify unsuccessful CI run
+    steps:
+      - name: Notify in Slack channel
+        if: ${{ needs.build_multiarch.result != 'success' || needs.deploy_manifests.result != 'success' }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.CI_SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#CC0000",
+                  "fallback": "Unsuccessful bitnami/minideb CI pipeline",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*Unsuccessful `bitnami/minideb` CI pipeline*"
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "The CI pipeline for <${{ github.event.head_commit.url }}|bitnami/minideb@${{ github.event.head_commit.id }}> did not succeed. Check the related <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|action run> for more information."
+                      }
+                    }
+                  ]
+                }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.CI_SLACK_BOT_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,5 +120,7 @@ jobs:
                     }
                   ]
                 }
+              ]
+            }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.CI_SLACK_BOT_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     name: Notify unsuccessful CI run
     steps:
       - name: Notify in Slack channel
-        if: ${{ needs.build_multiarch.result != 'success' || needs.deploy_manifests.result != 'success' }}
+        if: ${{ needs.build_multiarch.result == 'failure' || needs.deploy_manifests.result == 'failure' }}
         uses: slackapi/slack-github-action@v1.23.0
         with:
           payload: |
@@ -117,5 +117,5 @@ jobs:
               ]
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.TEST_CI_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
**Description of the change**

As of now, we do not have any way to notify the team when a run of the CI Pipeline workflow fails so failures in it can be easily missed.

This PR adds the feature to notify when the CI Pipeline does not succeed via Slack. These notifications will be sent to a private Slack channel where every interested agent part of the "Fix build process" team is.

**Benefits**

Improves awareness of CI pipeline health and fixes its triggering condition.