### PR TITLE
Support Debian 12/bookworm

### DIFF
--- a/mkimage
+++ b/mkimage
@@ -78,7 +78,7 @@ repo_url="http://deb.debian.org/debian"
 sec_repo_url="http://security.debian.org/"
 
 echo -e "deb ${repo_url} $DIST main" > "$rootfsDir/etc/apt/sources.list"
-if [ "$DIST" == "bullseye" ]; then
+if [ "$DIST" == "bullseye" ] || [ "$DIST" == "bookworm" ]; then
     echo "deb ${repo_url} $DIST-updates main" >> "$rootfsDir/etc/apt/sources.list"
     echo "deb ${sec_repo_url} $DIST-security main" >> "$rootfsDir/etc/apt/sources.list"
 elif [ "$DIST" != "unstable" ]; then


### PR DESCRIPTION
Support building Debian 12/bookworm images.

This is just setting the correct `updates` repository similar to what was required to support Debian 11/bullseye (see #110)