### PR TITLE
Only run scheduled jobs on bitnami/minideb repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
   shellcheck:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
+    if: github.event_name != 'schedule' || github.repository == 'bitnami/minideb'
     name: Shellcheck
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
I'm assuming the scheduled jobs are mainly to keep the images up-to-date. For most repository forks there is no real need to run these builds on a schedule and just use up build resources necessarily.