### PR TITLE
refactor(qemu): improve qemu deps

### DIFF
--- a/install-qemu.sh
+++ b/install-qemu.sh
@@ -15,5 +15,5 @@ while do_sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/nu
 done
 
 do_sudo apt-get update
-do_sudo apt-get install -y qemu-kvm libvirt-bin qemu-utils genisoimage virtinst curl rsync qemu-system-x86 qemu-system-arm cloud-image-utils
+do_sudo apt-get install -y qemu-kvm libvirt-daemon-system libvirt-clients qemu-utils genisoimage virtinst curl rsync qemu-system-x86 qemu-system-arm cloud-image-utils
 


### PR DESCRIPTION
**Description of the change**

replace `libvirt-bin` with `libvirt-daemon-system libvirt-clients` 

**Benefits**

No need to switch to an unstable source.

**Additional information**

Ref: https://wiki.debian.org/KVM#Installation

Packages: https://packages.debian.org/en/sid/libvirt-bin

![55-30 11 55@2x](https://github.com/bitnami/minideb/assets/8198408/c6d4807b-b074-4eda-8bc5-ec3940b7af32)

