### PR TITLE
mkimage: Remove device nodes

### DIFF
--- a/mkimage
+++ b/mkimage
@@ -34,6 +34,7 @@ DIRS_TO_TRIM="/usr/share/man
 /usr/share/locale
 /var/log
 /usr/share/info
+/dev
 "
 
 debootstrap_arch_args=( )


### PR DESCRIPTION
**Description of the change**

Remove extraneous device nodes

**Benefits**

There's no reason to ship them, the image will be smaller and compatible with ostree.

**Possible drawbacks**

None

**Applicable issues**

Closes: https://github.com/bitnami/minideb/issues/171

**Additional information**

I didn't test this