### PR TITLE
github-actions: Add gchat notification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron:  '0 0 * * *'
+# Remove all permissions by default
+permissions: {}
 env:
   BASENAME: bitnami/minideb
   LATEST: bookworm
@@ -36,7 +38,6 @@ jobs:
       - name: Verify scripts with shellcheck
         run: |
           bash shellcheck
-
   build_multiarch:
     runs-on: ubuntu-22.04
     needs: [ shellcheck ]
@@ -44,7 +45,6 @@ jobs:
       matrix:
         dist: [bullseye, bookworm]
         arch: [amd64, arm64]
-
     name: Build ${{ matrix.dist }} on ${{ matrix.arch }}
     steps:
       - name: Check out repository
@@ -68,7 +68,6 @@ jobs:
           if ${{ matrix.dist == env.LATEST }} ; then
              bash pushone "latest" "${{ matrix.arch }}"
           fi
-
   deploy_manifests:
     runs-on: ubuntu-22.04
     needs: [ build_multiarch ]
@@ -83,7 +82,6 @@ jobs:
       - name: Push Manifests
         run: |
           DISTS="bullseye bookworm latest" bash pushmanifest
-
   # If the CI Pipeline does not succeed we should notify the interested agents
   notify:
     name: Send notification

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,38 +85,15 @@ jobs:
           DISTS="bullseye bookworm latest" bash pushmanifest
 
   # If the CI Pipeline does not succeed we should notify the interested agents
-  slack-notif:
-    runs-on: ubuntu-22.04
+  notify:
+    name: Send notification
     needs:
       - build_multiarch
       - deploy_manifests
-    if: github.repository == 'bitnami/minideb'
-    name: Notify unsuccessful CI run
-    steps:
-      - name: Notify in Slack channel
-        if: ${{ needs.build_multiarch.result == 'failure' || needs.deploy_manifests.result == 'failure' }}
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          payload: |
-            {
-              "text": "*Unsuccessful `bitnami/minideb` CI pipeline*",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Unsuccessful `bitnami/minideb` CI pipeline*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "The CI pipeline for `bitnami/minideb` did not succeed. Check the related <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|action run> for more information."
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    if: ${{ always() && github.repository == 'bitnami/minideb' && (needs.build_multiarch.result == 'failure' || needs.deploy_manifests.result == 'failure') }}
+    uses: bitnami/support/.github/workflows/gchat-notification.yml@main
+    with:
+      workflow: ${{ github.workflow }}
+      job-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      webhook-url: ${{ secrets.GCHAT_CONTENT_ALERTS_WEBHOOK_URL }}


### PR DESCRIPTION
### Description of the change

This PR adds GChat notifications to the CD pipeline.

When the pipeline fails, it will notify the team with a message using the gchat-notification worflow from bitnami/support

### Possible drawbacks

None known.
