### PR TITLE
feature(aws-gallery): Publish minideb images to AWS ECR public Gallery

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,8 +91,6 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_REGISTRY: docker.io
-          DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
         run: |
           DISTS="bullseye bookworm latest" bash pushmanifest
       - name: Push Manifests to AWS

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,15 +1,11 @@
-# This is a basic workflow to help you get started with Actions
-
-name: CI
+name: CD
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push on the master branch
   push:
     branches:
       - master
-  pull_request:
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   schedule:
@@ -30,7 +26,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Install Dependencies
         run: |
           sudo apt-get -qq update
@@ -48,7 +44,7 @@ jobs:
     name: Build ${{ matrix.dist }} on ${{ matrix.arch }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Use local build action
         id: build
         uses: ./.github/actions/build
@@ -56,14 +52,29 @@ jobs:
           dist: "${{ matrix.dist }}"
           platform: "${{ matrix.arch }}"
           is_latest: ${{ matrix.dist == env.LATEST }}
-      - name: Push
+      - name: Push to DockerHUB
         if: github.repository == 'bitnami/minideb' && github.ref == 'refs/heads/master'
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_REGISTRY: docker.io
           DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
         run: |
+          bash pushone "${{ matrix.dist }}" "${{ matrix.arch }}"
+          if ${{ matrix.dist == env.LATEST }} ; then
+             bash pushone "latest" "${{ matrix.arch }}"
+          fi
+      - name: Push to AWS
+        if: github.repository == 'bitnami/minideb' && github.ref == 'refs/heads/master'
+        env:
+          DOCKER_USERNAME: AWS
+          DOCKER_REGISTRY: public.ecr.aws
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PUBLIC_GALLERY_KEY_ID }}
+          AWS_ACCESS_SECRET_KEY: ${{ secrets.AWS_PUBLIC_GALLERY_SECRET_KEY }}
+        run: |
+          # AWS login
+          export DOCKER_PASSWORD="$(aws ecr-public get-login-password --region us-east-1)"
           bash pushone "${{ matrix.dist }}" "${{ matrix.arch }}"
           if ${{ matrix.dist == env.LATEST }} ; then
              bash pushone "latest" "${{ matrix.arch }}"
@@ -72,15 +83,27 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [ build_multiarch ]
     if: github.repository == 'bitnami/minideb' && github.ref == 'refs/heads/master'
-    env:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
-      DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Push Manifests
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Push Manifests to DockerHUB
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_REGISTRY: docker.io
+          DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
+          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
         run: |
+          DISTS="bullseye bookworm latest" bash pushmanifest
+      - name: Push Manifests to AWS
+        env:
+          DOCKER_USERNAME: AWS
+          DOCKER_REGISTRY: public.ecr.aws
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PUBLIC_GALLERY_KEY_ID }}
+          AWS_ACCESS_SECRET_KEY: ${{ secrets.AWS_PUBLIC_GALLERY_SECRET_KEY }}
+        run: |
+          # AWS login
+          export DOCKER_PASSWORD="$(aws ecr-public get-login-password --region us-east-1)"
           DISTS="bullseye bookworm latest" bash pushmanifest
   # If the CI Pipeline does not succeed we should notify the interested agents
   notify:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on pull request events
+  pull_request:
+# Remove all permissions by default
+permissions: {}
+env:
+  BASENAME: bitnami/minideb
+  LATEST: bookworm
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  shellcheck:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-22.04
+    name: Shellcheck
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install Dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get install -y shellcheck
+      - name: Verify scripts with shellcheck
+        run: |
+          bash shellcheck
+  build_multiarch:
+    runs-on: ubuntu-22.04
+    needs: [ shellcheck ]
+    strategy:
+      matrix:
+        dist: [bullseye, bookworm]
+        arch: [amd64, arm64]
+    name: Build ${{ matrix.dist }} on ${{ matrix.arch }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Use local build action
+        id: build
+        uses: ./.github/actions/build
+        with:
+          dist: "${{ matrix.dist }}"
+          platform: "${{ matrix.arch }}"
+          is_latest: ${{ matrix.dist == env.LATEST }}

--- a/pushmanifest
+++ b/pushmanifest
@@ -10,6 +10,7 @@ latest
 "}
 
 BASENAME=bitnami/minideb
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-"docker.io"}
 PLATFORMS=${PLATFORMS:-amd64 arm64}
 DRY_RUN=${DRY_RUN:-}
 read -r -a ARCHS <<<"$PLATFORMS"
@@ -18,7 +19,8 @@ run_docker() {
     if [[ -n "${DRY_RUN:-}" ]]; then
         echo "DRY RUN docker ${*}"
     else
-        docker "$@"
+#        docker "$@"
+        beep
     fi
 }
 
@@ -60,7 +62,7 @@ for DIST in $DISTS; do
     tags+=("$DIST")
 done
 
-repositories=("$BASENAME")
+repositories=("${DOCKER_REGISTRY}/${BASENAME}")
 
 for tag in "${tags[@]}"; do
     for repo in "${repositories[@]}"; do

--- a/pushmanifest
+++ b/pushmanifest
@@ -19,8 +19,7 @@ run_docker() {
     if [[ -n "${DRY_RUN:-}" ]]; then
         echo "DRY RUN docker ${*}"
     else
-#        docker "$@"
-        beep
+        docker "$@"
     fi
 }
 
@@ -40,7 +39,7 @@ list_includes() {
 }
 
 if [ -n "${DOCKER_PASSWORD:-}" ]; then
-    echo "$DOCKER_PASSWORD" | run_docker login -u "$DOCKER_USERNAME" --password-stdin
+    echo "$DOCKER_PASSWORD" | run_docker login -u "$DOCKER_USERNAME" --password-stdin "${DOCKER_REGISTRY}"
 fi
 
 push_manifest() {

--- a/pushone
+++ b/pushone
@@ -8,9 +8,10 @@ DIST=${1:?Specify the distrubution name}
 PLATFORM=${2:-amd64}
 
 BASENAME=bitnami/minideb
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-"docker.io"}
 
 if [ -n "${DOCKER_PASSWORD:-}" ]; then
-    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin "${DOCKER_REGISTRY}"
 fi
 
 ENABLE_DOCKER_CONTENT_TRUST=0
@@ -25,7 +26,8 @@ fi
 
 push() {
     local dist="$1"
-    DOCKER_CONTENT_TRUST=${ENABLE_DOCKER_CONTENT_TRUST} docker push "${BASENAME}:${dist}"
+    docker tag "${BASENAME}:${dist}" "${DOCKER_REGISTRY}/${BASENAME}:${dist}"
+    DOCKER_CONTENT_TRUST=${ENABLE_DOCKER_CONTENT_TRUST} docker push "${DOCKER_REGISTRY}/${BASENAME}:${dist}"
 }
 
 push "$DIST-${PLATFORM}"


### PR DESCRIPTION
**Description of the change**

* Split the `main` workflow into `CI` and `CD` worklfows.
* Publish new minideb images in AWS ECR Public Gallery

**Benefits**

* Split workflow responsabilities to avoid the use of secrets in Pull request events. 
* Keep minideb image updated in AWS ECR gallery.

**Possible drawbacks**

In case of error, we minideb image won't be published in DockerHub
