### PR TITLE
Fix: Use HTTPS for Debian repos to avoid Release file error (#192)

### DIFF
--- a/mkimage
+++ b/mkimage
@@ -71,9 +71,9 @@ fi
 
 rootfs_chroot bash debootstrap/debootstrap --second-stage
 
-repo_url="http://deb.debian.org/debian"
+repo_url="https://deb.debian.org/debian"
 sec_repo_url_1="${repo_url}-security"
-sec_repo_url_2="http://security.debian.org/debian-security"
+sec_repo_url_2="https://security.debian.org/debian-security"
 
 echo -e "deb ${repo_url} $DIST main" > "$rootfsDir/etc/apt/sources.list"
 if [ "$DIST" == "bookworm" ]; then


### PR DESCRIPTION
**Description of the change**

This change updates the Debian repository URLs in the build scripts from `http` to `https`. Specifically:

* `repo_url` is now `https://deb.debian.org/debian`
* `sec_repo_url_1` is now `https://deb.debian.org/debian-security`
* `sec_repo_url_2` is now `https://security.debian.org/debian-security`

This addresses the issue where the build fails due to missing `Release` files when using HTTP, as described in issue https://github.com/bitnami/minideb/issues/192.

---

**Benefits**

* Ensures compatibility with current Debian mirror requirements.
* Prevents build failures caused by Debian dropping `Release` files over HTTP.
* Improves security by using encrypted connections to download packages.

---

**Possible drawbacks**

* None known. All updated URLs point to the same mirrors, just over HTTPS.

---

**Applicable issues**

- Fixes #192

---

**Additional information**

* The image was successfully built locally after applying this patch using `make build`.
* No functional regressions observed.
