### PR TITLE
use gha arm-based workers to build arm images

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: "Install QEMU"
       run: |
         set -x
-        if [[ "${{ inputs.platform }}" == "arm64" ]]; then
+        if [[ "${{ inputs.platform }}" == "arm64" && "$(uname -m)" != "aarch64"  ]]; then
           echo "Installing QEMU"
           sudo apt-get update -qq && sudo apt-get install -y qemu-user-static
         else

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,13 +35,15 @@ jobs:
         run: |
           bash shellcheck
   build_multiarch:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.arch.platform }}
     needs: [ shellcheck ]
     strategy:
       matrix:
         dist: [bullseye, bookworm, trixie]
-        arch: [amd64, arm64]
-    name: Build ${{ matrix.dist }} on ${{ matrix.arch }}
+        arch:
+          - { name: amd64, platform: ubuntu-24.04 }
+          - { name: arm64, platform: ubuntu-24.04-arm }
+    name: Build ${{ matrix.dist }} on ${{ matrix.arch.name }}
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -50,7 +52,7 @@ jobs:
         uses: ./.github/actions/build
         with:
           dist: "${{ matrix.dist }}"
-          platform: "${{ matrix.arch }}"
+          platform: "${{ matrix.arch.name }}"
           is_latest: ${{ matrix.dist == env.LATEST }}
       - name: Push to DockerHUB
         if: github.repository == 'bitnami/minideb' && github.ref == 'refs/heads/master'
@@ -61,9 +63,9 @@ jobs:
           DOCKER_CONTENT_TRUST_REPOSITORY_KEY: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_KEY }}
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE }}
         run: |
-          bash pushone "${{ matrix.dist }}" "${{ matrix.arch }}"
+          bash pushone "${{ matrix.dist }}" "${{ matrix.arch.name }}"
           if ${{ matrix.dist == env.LATEST }} ; then
-             bash pushone "latest" "${{ matrix.arch }}"
+             bash pushone "latest" "${{ matrix.arch.name }}"
           fi
       - name: Push to AWS
         if: github.repository == 'bitnami/minideb' && github.ref == 'refs/heads/master'
@@ -75,9 +77,9 @@ jobs:
         run: |
           # AWS login
           export DOCKER_PASSWORD="$(aws ecr-public get-login-password --region us-east-1)"
-          bash pushone "${{ matrix.dist }}" "${{ matrix.arch }}"
+          bash pushone "${{ matrix.dist }}" "${{ matrix.arch.name }}"
           if ${{ matrix.dist == env.LATEST }} ; then
-             bash pushone "latest" "${{ matrix.arch }}"
+             bash pushone "latest" "${{ matrix.arch.name }}"
           fi
   deploy_manifests:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,15 @@ jobs:
         run: |
           bash shellcheck
   build_multiarch:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.arch.platform }}
     needs: [ shellcheck ]
     strategy:
       matrix:
         dist: [bullseye, bookworm, trixie]
-        arch: [amd64, arm64]
-    name: Build ${{ matrix.dist }} on ${{ matrix.arch }}
+        arch:
+            - { name: amd64, platform: ubuntu-24.04 }
+            - { name: arm64, platform: ubuntu-24.04-arm }
+    name: Build ${{ matrix.dist }} on ${{ matrix.arch.name }}
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -43,5 +45,5 @@ jobs:
         uses: ./.github/actions/build
         with:
           dist: "${{ matrix.dist }}"
-          platform: "${{ matrix.arch }}"
+          platform: "${{ matrix.arch.name }}"
           is_latest: ${{ matrix.dist == env.LATEST }}


### PR DESCRIPTION
**Description of the change**

Since the beginning of the year GH offers ARM-based workers for public repo actions.
This PR makes CD workflow to build ARM-based images on ARM-based workers.

**Benefits**

ARM build time highly reduced
