### PR TITLE
Optional build with Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ To test the resulting image:
 $ sudo make test-trixie
 ```
 
+Building the image with podman instead of docker is possible, if you replace docker with podman in 4 scripts:
+```
+$ sed -i "s/docker /podman /g" buildone dockerdiff import test
+```
+
 ## Building Minideb for foreign architecture
 Make commands shown above will build an image for the architecture you are currently working on.
 To build an image for a foreign architecture (for example to build a multi-arch image), we provide a

--- a/import
+++ b/import
@@ -31,7 +31,7 @@ import() {
     local MANIFEST="$(echo -n "$MANIFEST_TEMPLATE" | sed -e "s/%CONF_SHA%/$CONF_SHA/g" -e "s/%LAYERSUM%/$LAYERSUM/g")"
     echo -n "$MANIFEST" > $TDIR/manifest.json
     tar cf $TDIR/import.tar -C $TDIR manifest.json "${CONF_SHA}.json" "$LAYERSUM"
-    local ID=$(docker load -i $TDIR/import.tar | awk '{print $4}')
+    local ID=$(docker load -i $TDIR/import.tar | grep Loaded\ image | awk '{print $NF}')
     if [ "$ID" != "sha256:$CONF_SHA" ]; then
         echo "Failed to load $ID correctly, expected id to be $CONF_SHA, source in $TDIR" >&2
         exit 1


### PR DESCRIPTION
**Build with podman**

This pull requests adds:
- a more generic approach to catch the hash from `load` command of docker/podman
- hints in the README, how to build with podman

**Benefits**

Daomonless build with **podman** as option to the build.

**Possible drawbacks**

Not known.

**Applicable issues**

None.