### PR TITLE
Fix keyring copy on Debian 13/trixie

### DIFF
--- a/mkimage
+++ b/mkimage
@@ -17,7 +17,7 @@ exec 2> >(tee -ia "$LOGFILE" >&2)
 
 DEBOOTSTRAP_DIR=$(mktemp -d)
 cp -a /usr/share/debootstrap/* "$DEBOOTSTRAP_DIR"
-cp -a /usr/share/keyrings/debian-archive-keyring.gpg "$DEBOOTSTRAP_DIR"
+cp -aL /usr/share/keyrings/debian-archive-keyring.gpg "$DEBOOTSTRAP_DIR"
 cp -a "${ROOT}/debootstrap/"* "${DEBOOTSTRAP_DIR}/scripts"
 
 KEYRING=$DEBOOTSTRAP_DIR/debian-archive-keyring.gpg


### PR DESCRIPTION
**Description of the change**

Fix running `mkimage` on Debian 13/trixie

**Benefits**

The `mkimage` script will run on Debian 13/trixie

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

It seems as though the `/usr/share/keyrings/debian-archive-keyring.gpg` on Debian 13/trixie is actually a symlink to `debian-archive-keyring.pgp` in the same directory. This means that the `cp -a` in `mkimage` copies the symlink and not the actual keyring, resulting in the following error:

    E: specified keyring file (/<tmpdir>/debian-archive-keyring.gpg) not found

Using `cp -aL` ensures the file that is symlink source actually gets copied.