### PR TITLE
chore: migrate from deprecated docker trust to cosign

### DIFF
--- a/pushall
+++ b/pushall
@@ -14,19 +14,14 @@ if [ -n "${DOCKER_PASSWORD:-}" ]; then
     docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 fi
 
-ENABLE_DOCKER_CONTENT_TRUST=0
-if [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE:-}" ] && [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY:-}" ]; then
-    tmpdir=$(mktemp -d)
-    (cd "${tmpdir}" && bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" | base64 -d > key')
-    chmod 400 "${tmpdir}/key"
-    docker trust key load "${tmpdir}/key"
-    rm -rf "${tmpdir}"
-    export ENABLE_DOCKER_CONTENT_TRUST=1
-fi
-
 push() {
     local dist="$1"
-    DOCKER_CONTENT_TRUST=${ENABLE_DOCKER_CONTENT_TRUST} docker push "${BASENAME}:${dist}"
+    local image="${BASENAME}:${dist}"
+    docker push "${image}"
+    
+    if [ -n "${COSIGN_PRIVATE_KEY:-}" ] && [ -n "${COSIGN_PASSWORD:-}" ]; then
+        cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${image}"
+    fi
 }
 
 for DIST in $DISTS; do

--- a/pushmanifest
+++ b/pushmanifest
@@ -54,6 +54,14 @@ push_manifest() {
     done
     run_docker manifest create "$image" "${arch_images[@]}"
     run_docker manifest push "$image"
+    
+    if [ -n "${COSIGN_PRIVATE_KEY:-}" ] && [ -n "${COSIGN_PASSWORD:-}" ]; then
+        if [[ -n "${DRY_RUN:-}" ]]; then
+            echo "DRY RUN cosign sign --yes --key env://COSIGN_PRIVATE_KEY ${image}"
+        else
+            cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${image}"
+        fi
+    fi
 }
 
 tags=()

--- a/pushone
+++ b/pushone
@@ -14,20 +14,15 @@ if [ -n "${DOCKER_PASSWORD:-}" ]; then
     echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin "${DOCKER_REGISTRY}"
 fi
 
-ENABLE_DOCKER_CONTENT_TRUST=0
-if [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE:-}" ] && [ -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY:-}" ]; then
-    tmpdir=$(mktemp -d)
-    (cd "${tmpdir}" && bash -c 'echo -n "${DOCKER_CONTENT_TRUST_REPOSITORY_KEY}" | base64 -d > key')
-    chmod 400 "${tmpdir}/key"
-    docker trust key load "${tmpdir}/key"
-    rm -rf "${tmpdir}"
-    export ENABLE_DOCKER_CONTENT_TRUST=1
-fi
-
 push() {
     local dist="$1"
-    docker tag "${BASENAME}:${dist}" "${DOCKER_REGISTRY}/${BASENAME}:${dist}"
-    DOCKER_CONTENT_TRUST=${ENABLE_DOCKER_CONTENT_TRUST} docker push "${DOCKER_REGISTRY}/${BASENAME}:${dist}"
+    local image="${DOCKER_REGISTRY}/${BASENAME}:${dist}"
+    docker tag "${BASENAME}:${dist}" "${image}"
+    docker push "${image}"
+    
+    if [ -n "${COSIGN_PRIVATE_KEY:-}" ] && [ -n "${COSIGN_PASSWORD:-}" ]; then
+        cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${image}"
+    fi
 }
 
 push "$DIST-${PLATFORM}"


### PR DESCRIPTION
## Summary
- Replaces deprecated Docker Content Trust (Notary v1) signing logic with Cosign.
- Modern Docker clients (26+) no longer support `docker trust`.
- `pushone`, `pushall`, and `pushmanifest` now look for `COSIGN_PRIVATE_KEY` and `COSIGN_PASSWORD` environment variables to sign the pushed images via `cosign sign`.

ai-assisted=yes